### PR TITLE
Update nginx.conf

### DIFF
--- a/apps/rda/nginx.conf
+++ b/apps/rda/nginx.conf
@@ -6,4 +6,8 @@ server {
     include /etc/nginx/mime.types;
     try_files $uri $uri/ /index.html;
   }
+
+  location /api/search/ {
+    proxy_pass https://es.ohsmart.dansdemo.nl/;
+  }
 }


### PR DESCRIPTION
## Description

Problem is that the request for the elasticsearch instance resolves back into the container. This creates a loop (and starts a request on an endpoint not accepting a POST, hence triggering a 405). Worked around it by using a nginx reverse proxy; the request hits the proxy first now, and then resolves properly.

Actual problem appears to be software though, should be fixed through there.

## Related Issue(s)

List and link to any issue(s) this PR addresses, if applicable.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Refactoring (changes that neither fixes a bug nor adds a feature)
- [ ] Performance improvement (changes that improve existing functionality)
- [ ] Test update (changes that modify tests)
- [ ] Other (please describe):

## Checklist

- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.

## Screenshots

If applicable, add screenshots to help explain your problem or demonstrate the change.
