### PR TITLE
Add validation for GitHub repository URL

### DIFF
--- a/apps/swh/src/config/formsections/citation.ts
+++ b/apps/swh/src/config/formsections/citation.ts
@@ -205,10 +205,12 @@ const section: InitialSectionType = {
       type: 'text',
       name: 'repository_url',
       label: 'Repository URL',
+      validation: "github-uri",
       description: {
-        en: 'The Repository URL of the software to be archived',
-        nl: 'De Repository URL van de software die gearchiveerd moet worden',
+        en: 'The Repository URL of the software to be archived (Note: currently only Github is supported)',
+        nl: 'De Repository URL van de software die gearchiveerd moet worden (Opmerking: momenteel wordt alleen Github ondersteund)',
       },
+      placeholder: 'https://github.com/...'
     },
     {
       type: 'text',

--- a/packages/deposit/src/features/metadata/metadataHelpers.ts
+++ b/packages/deposit/src/features/metadata/metadataHelpers.ts
@@ -11,6 +11,8 @@ export const validateData = (type: ValidationType, value: string): boolean => {
       return /^[\w-.]+@([\w-]+\.)+[\w-]{2,4}$/.test(value.toLowerCase());
     case 'uri':
       return /^(https?|ftp):\/\/[^\s/$.?#]*\.[^\s]*$/.test(value.toLowerCase());
+    case 'github-uri':
+      return /^https:\/\/github\.com\/.*$/.test(value.toLowerCase());
     default:
       return true;
   }

--- a/packages/deposit/src/types/MetadataFields.ts
+++ b/packages/deposit/src/types/MetadataFields.ts
@@ -149,7 +149,7 @@ export interface OptionsType {
 };
 
 // Validation for text fields
-export type ValidationType = 'email' | 'uri' | 'number';
+export type ValidationType = 'email' | 'uri' | 'number' | 'github-uri';
 
 // Format to return API response in, used by RTK's transformResponse
 export interface AutocompleteAPIFieldData {


### PR DESCRIPTION
## Description

This PR introduces a change to the input field validation in the `metadataHelpers.ts` file. The `validateData` function now includes a case for 'github-uri', which checks if the input value starts with 'https://github.com/'. This ensures that only valid GitHub URLs are accepted by the input field.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring (changes that neither fixes a bug nor adds a feature)
- [ ] Performance improvement (changes that improve existing functionality)
- [ ] Test update (changes that modify tests)
- [ ] Other (please describe):

## Checklist

- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
