### PR TITLE
Enforce completeness in optional field groups when partially filled

### DIFF
--- a/apps/swh/src/config/formsections/citation.ts
+++ b/apps/swh/src/config/formsections/citation.ts
@@ -154,6 +154,20 @@ const section: InitialSectionType = {
       disabled: true,
     },
     {
+      type: "text",
+      label: {
+        en: "Software Author",
+        nl: "Software auteur",
+      },
+      name: "software_author",
+      autofill: "name",
+      required: true,
+      description: {
+        en: "Author of the software",
+        nl: "Auteur van de software",
+      },
+    },
+    {
       type: "group",
       label: {
         en: "Additional Authors",

--- a/apps/swh/src/config/formsections/citation.ts
+++ b/apps/swh/src/config/formsections/citation.ts
@@ -175,6 +175,7 @@ const section: InitialSectionType = {
       },
       name: "additional_authors",
       repeatable: true,
+      compleetGroup: true,
       description: {
         en: "Additional authors of the dataset and or software",
         nl: "Extra auteurs van het dataset en of software",

--- a/packages/deposit/src/types/MetadataFields.ts
+++ b/packages/deposit/src/types/MetadataFields.ts
@@ -98,6 +98,10 @@ export interface AutocompleteFieldType
 export interface GroupedFieldType
   extends Omit<BasisFieldType, "value" | "touched"> {
   type: "group"; // This type groups multiple single fields
+  /**
+   * If true, the group is required if at least one of the fields is set.
+   */
+  compleetGroup?: boolean;
   fields: InputField[];
   value?: never;
   validation?: never;


### PR DESCRIPTION
## Description

Ensure optional groups become required when any field is filled to maintain complete groups.

## Related Issue(s)

List and link to any issue(s) this PR addresses, if applicable.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring (changes that neither fixes a bug nor adds a feature)
- [ ] Performance improvement (changes that improve existing functionality)
- [ ] Test update (changes that modify tests)
- [ ] Other (please describe):

## Checklist

- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [ ] My changes generate no new warnings.

## Screenshots

If applicable, add screenshots to help explain your problem or demonstrate the change.
