### PR TITLE
RDA-11 Add initial value of English for language 

### DIFF
--- a/apps/rda/src/config/formsections/administrative.ts
+++ b/apps/rda/src/config/formsections/administrative.ts
@@ -81,6 +81,7 @@ const section: InitialSectionType = {
         nl: "Taal van het deposit",
       },
       options: "languageList",
+      value: { label: "English", value: "en" },
     },
   ],
 };


### PR DESCRIPTION
## Description
The language field inside of the administrative section now has English as the default language.

## Related Issue(s)

Jira ticket [RDA-11](https://drivenbydata.atlassian.net/browse/RDA-11)

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring (changes that neither fixes a bug nor adds a feature)
- [ ] Performance improvement (changes that improve existing functionality)
- [ ] Test update (changes that modify tests)
- [ ] Other (please describe):

## Checklist

- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.

[RDA-11]: https://drivenbydata.atlassian.net/browse/RDA-11?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ