### PR TITLE
Rda 14 Set access type default to "Open"

### DIFF
--- a/apps/rda/src/config/formsections/rights.ts
+++ b/apps/rda/src/config/formsections/rights.ts
@@ -64,6 +64,7 @@ const section: InitialSectionType = {
           value: "closed",
         },
       ],
+      value: { label: "Open", value: "open" },
     },
     {
       type: "autocomplete",


### PR DESCRIPTION
## Description

Sets the field access type in the rights section to have the default value of open.

## Related Issue(s)

Jira ticket [RDA-14](https://drivenbydata.atlassian.net/browse/RDA-14?atlOrigin=eyJpIjoiMDcwOGNlOTRjODMxNGRkOTljNDUwOGU3NTM1MjhlYmQiLCJwIjoiaiJ9)

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring (changes that neither fixes a bug nor adds a feature)
- [ ] Performance improvement (changes that improve existing functionality)
- [ ] Test update (changes that modify tests)
- [ ] Other (please describe):

## Checklist

- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.


[RDA-14]: https://drivenbydata.atlassian.net/browse/RDA-14?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ