### PR TITLE
Rda 15 - Set license default to "CC-BY-4.0"

### DIFF
--- a/apps/rda/src/config/formsections/rights.ts
+++ b/apps/rda/src/config/formsections/rights.ts
@@ -79,6 +79,11 @@ const section: InitialSectionType = {
         nl: "Eén of meerdere specifieke licenties",
       },
       options: "licenses",
+      value: {
+        label: "CC-BY-4.0 Creative Commons Attribution 4.0",
+        value: "https://creativecommons.org/licenses/by/4.0/",
+        id: "CC-BY-4.0",
+      },
     },
   ],
 };


### PR DESCRIPTION
## Description

This PR sets the default value of the field license in the section rights to "CC-BY-4.0.

## Related Issue(s)

Jira ticket [RDA-15](https://drivenbydata.atlassian.net/browse/RDA-15?atlOrigin=eyJpIjoiNWExY2M2M2RiMTM1NDViZWFlZjhkMzk2NzY4ZWUwZDUiLCJwIjoiaiJ9)

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring (changes that neither fixes a bug nor adds a feature)
- [ ] Performance improvement (changes that improve existing functionality)
- [ ] Test update (changes that modify tests)
- [ ] Other (please describe):

## Checklist

- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.


[RDA-15]: https://drivenbydata.atlassian.net/browse/RDA-15?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ