### PR TITLE
RDA 7 | Make first Author entry mandatory

### DIFF
--- a/apps/rda/src/config/formsections/citation.ts
+++ b/apps/rda/src/config/formsections/citation.ts
@@ -101,6 +101,7 @@ const section: InitialSectionType = {
           },
           options: "orcid",
           allowFreeText: true,
+          required: true,
         },
         {
           type: "autocomplete",
@@ -113,6 +114,7 @@ const section: InitialSectionType = {
             en: "Type of contribution",
             nl: "Type bijdrage",
           },
+          required: true,
           options: [
             {
               label: {

--- a/apps/rda/src/config/formsections/citation.ts
+++ b/apps/rda/src/config/formsections/citation.ts
@@ -76,6 +76,21 @@ const section: InitialSectionType = {
       },
     },
     {
+      type: "autocomplete",
+      name: "firstAuthor",
+      label: {
+        en: "Author",
+        nl: "Auteur",
+      },
+      required: true,
+      options: "orcid",
+      allowFreeText: true,
+      description: {
+        en: "Author for this deposit. Every submission requires at least one author to be specified. Additional contributors can be added in the Contributors section below.",
+        nl: "Auteur voor dit deposit. Elke inzending vereist dat ten minste één auteur wordt opgegeven. Extra bijdragers kunnen worden toegevoegd in de sectie Bijdragers hieronder.",
+      },
+    },
+    {
       type: "group",
       name: "contributors",
       label: {
@@ -101,7 +116,6 @@ const section: InitialSectionType = {
           },
           options: "orcid",
           allowFreeText: true,
-          required: true,
         },
         {
           type: "autocomplete",
@@ -114,7 +128,6 @@ const section: InitialSectionType = {
             en: "Type of contribution",
             nl: "Type bijdrage",
           },
-          required: true,
           options: [
             {
               label: {


### PR DESCRIPTION
## Description

Introduced a separate field for an author so we can enforce an minimum of 1 author without much additional complexity.

## Related Issue(s)

Jira ticket [RDA-7](https://drivenbydata.atlassian.net/browse/RDA-7?atlOrigin=eyJpIjoiYjk5ZGNkMDAxNDVjNDhmZWIyNjdhNjA3MTFhZTNmNTgiLCJwIjoiaiJ9)

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring (changes that neither fixes a bug nor adds a feature)
- [ ] Performance improvement (changes that improve existing functionality)
- [ ] Test update (changes that modify tests)
- [ ] Other (please describe):

## Checklist

- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.

[RDA-7]: https://drivenbydata.atlassian.net/browse/RDA-7?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ