### PR TITLE
RDA-8 | Conditional contributor field required

### DIFF
--- a/apps/rda/src/config/formsections/citation.ts
+++ b/apps/rda/src/config/formsections/citation.ts
@@ -107,6 +107,7 @@ const section: InitialSectionType = {
         {
           type: "autocomplete",
           name: "contributor",
+          toggleRequired: ["contributorType"],
           label: {
             en: "Contributor",
             nl: "Bijdrager",
@@ -121,6 +122,7 @@ const section: InitialSectionType = {
         {
           type: "autocomplete",
           name: "contributorType",
+          toggleRequired: ["contributor"],
           label: {
             en: "Contributor type",
             nl: "Type bijdrager",


### PR DESCRIPTION
## Description
The PR ensures that when an contributor is added in the citation field it will force all other group fields inside the contributor to be required.

## Related Issue(s)

Jira ticket [RDA-8](https://drivenbydata.atlassian.net/browse/RDA-8?atlOrigin=eyJpIjoiODUyYzc0YzhkNGJmNGYwNDgzYTQ4N2FhYWZiZjExMGYiLCJwIjoiaiJ9)

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring (changes that neither fixes a bug nor adds a feature)
- [ ] Performance improvement (changes that improve existing functionality)
- [ ] Test update (changes that modify tests)
- [ ] Other (please describe):

## Checklist

- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.


[RDA-8]: https://drivenbydata.atlassian.net/browse/RDA-8?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ