### PR TITLE
RDA-13 | Derive value from different fields. 

### DIFF
--- a/apps/rda/src/config/formsections/rights.ts
+++ b/apps/rda/src/config/formsections/rights.ts
@@ -19,6 +19,7 @@ const section: InitialSectionType = {
         en: "Name of the organisation or individual(s) owning the work",
         nl: "Naam van de organisatie of personen die eigenaar zijn van het werk",
       },
+      deriveFrom: "firstAuthor",
       multiApiValue: "orcid",
       options: ["ror", "orcid"],
     },

--- a/docs/deposit.md
+++ b/docs/deposit.md
@@ -247,6 +247,11 @@ Each section is a collapsible accordion in the front-end. A section is formatted
       // Auto generate the value of this field, based on a specific string. Only for text fields.
       // Value must be a string, or a language string object
       autoGenerateValue: "{{some_field_name}} has a value, and {{some_other_field}} also has one",
+
+      // Optional logic that enabled the field to be populated from the value derived from the specified field name.
+      // Value must be a single string.
+      // Will only trigger if the user hasn't `Touched` the field. (This is to prevent data loss)
+      deriveFrom: "name_of_field_to_derive_from"
     },
   ]
 }

--- a/packages/deposit/src/features/metadata/metadataSlice.ts
+++ b/packages/deposit/src/features/metadata/metadataSlice.ts
@@ -146,6 +146,28 @@ export const metadataSlice = createSlice({
         });
       }
 
+      // This logic will populate fields that have the `deriveFrom` property set.
+      // Currently it just sets the value of the field to the value of the field it derives from.
+      // @TODO: Currently it doesn't check if the field can support the value of the field it derives from.
+      Object.entries(state.fieldMap).forEach(([fieldName, fieldDef]) => {
+        if (fieldDef.deriveFrom === field.name) {
+          const isTouched = "touched" in state.fields[fieldName] ? state.fields[fieldName].touched : false;
+
+          // Only update if the field hasn't been touched by the user.
+          if (state.fields[fieldName] && !isTouched) {
+            state.fields[fieldName] = {
+                ...state.fields[fieldName],
+                value,
+                valid: true,
+                touched: false
+              };
+            
+            // Update section status for the derived field
+            updateSection(state.sections, state.fields, fieldDef, state.fieldMap);
+          }
+        }
+      });
+
       // Now set section status to reflect all field changes
       updateSection(state.sections, state.fields, field, state.fieldMap, groupName);
     },

--- a/packages/deposit/src/types/MetadataFields.ts
+++ b/packages/deposit/src/types/MetadataFields.ts
@@ -39,6 +39,7 @@ interface BasisFieldType {
   togglePrivateIds?: string[]; // filled programmatically with uuid's
   toggleTitleGeneration?: boolean; // determines if this field can toggle the forms auto title generation functionality
   fullWidth?: boolean; // set field to be 100% width instead of default 50%
+  deriveFrom?: string; // field name to derive value from
 }
 
 export interface TextFieldType extends BasisFieldType {


### PR DESCRIPTION
## Description
Introduces an property that allows the field to be set by an value derived from an specified field.

Do `derivedFrom` only triggers when the field has not been touched by the user.

## Related Issue(s)

Jira ticket [RDA-13](https://drivenbydata.atlassian.net/browse/RDA-13?atlOrigin=eyJpIjoiZDAzMDZhOGExM2JjNDAwYjgzM2FjZDFiZDVhYTBkYzUiLCJwIjoiaiJ9)

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring (changes that neither fixes a bug nor adds a feature)
- [ ] Performance improvement (changes that improve existing functionality)
- [ ] Test update (changes that modify tests)
- [ ] Other (please describe):

## Checklist

- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.


[RDA-13]: https://drivenbydata.atlassian.net/browse/RDA-13?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ