### PR TITLE
Rda-16 | Related work identifier field and repeatable group

### DIFF
--- a/apps/rda/src/config/formsections/relations.ts
+++ b/apps/rda/src/config/formsections/relations.ts
@@ -8,242 +8,270 @@ const section: InitialSectionType = {
   },
   fields: [
     {
-      type: "autocomplete",
-      name: "relatedto",
+      type: "group",
+      name: "relatedWorks",
       label: {
-        en: "Related to",
-        nl: "Gerelateerd aan",
+        en: "Related Works",
+        nl: "Gerelateerde Werken",
       },
-      required: true,
-      multiselect: true,
+      repeatable: true,
       description: {
-        en: "Other PID's, publications, projects",
-        nl: "Andere PID's, publicaties, projecten",
+        en: "Relation type to the related work",
+        nl: "Relatie type naar het gerelateerde werk",
       },
-      options: [
+      fields: [
         {
+          type: "autocomplete",
+          name: "relationType",
           label: {
-            en: "Is Cited By",
-            nl: "Wordt Geciteerd Door",
+            en: "Relation",
+            nl: "Relatie",
           },
-          value: "isCitedBy",
+          required: true,
+          multiselect: true,
+          description: {
+            en: "Other PID's, publications, projects",
+            nl: "Andere PID's, publicaties, projecten",
+          },
+          options: [
+            {
+              label: {
+                en: "Is Cited By",
+                nl: "Wordt Geciteerd Door",
+              },
+              value: "isCitedBy",
+            },
+            {
+              label: {
+                en: "Cites",
+                nl: "Citeert",
+              },
+              value: "cites",
+            },
+            {
+              label: {
+                en: "Is Supplement To",
+                nl: "Is Een Supplement Op",
+              },
+              value: "isSupplementTo",
+            },
+            {
+              label: {
+                en: "Is Supplemented By",
+                nl: "Wordt Aangevuld Door",
+              },
+              value: "isSupplementedBy",
+            },
+            {
+              label: {
+                en: "Is Continued By",
+                nl: "Wordt Voortgezet Door",
+              },
+              value: "isContinuedBy",
+            },
+            {
+              label: {
+                en: "Continues",
+                nl: "Gaat Verder",
+              },
+              value: "continues",
+            },
+            {
+              label: {
+                en: "Is Described By",
+                nl: "Wordt Beschreven Door",
+              },
+              value: "isDescribedBy",
+            },
+            {
+              label: {
+                en: "Describes",
+                nl: "Beschrijft",
+              },
+              value: "describes",
+            },
+            {
+              label: {
+                en: "Has Metadata",
+                nl: "Heeft Metadata",
+              },
+              value: "hasMetadata",
+            },
+            {
+              label: {
+                en: "Is Metadata For",
+                nl: "Is Metadata Voor",
+              },
+              value: "isMetadataFor",
+            },
+            {
+              label: {
+                en: "Is New Version Of",
+                nl: "Is Nieuwe Versie Van",
+              },
+              value: "isNewVersionOf",
+            },
+            {
+              label: {
+                en: "Is Previous Version Of",
+                nl: "Is Vorige Versie Van",
+              },
+              value: "isPreviousVersionOf",
+            },
+            {
+              label: {
+                en: "Is Part Of",
+                nl: "Is Onderdeel Van",
+              },
+              value: "isPartOf",
+            },
+            {
+              label: {
+                en: "Has Part",
+                nl: "Heeft Deel",
+              },
+              value: "hasPart",
+            },
+            {
+              label: {
+                en: "Is Referenced By",
+                nl: "Wordt Verwezen Door",
+              },
+              value: "isReferencedBy",
+            },
+            {
+              label: {
+                en: "References",
+                nl: "Verwijst",
+              },
+              value: "references",
+            },
+            {
+              label: {
+                en: "Is Documented By",
+                nl: "Wordt Gedocumenteerd Door",
+              },
+              value: "isDocumentedBy",
+            },
+            {
+              label: {
+                en: "Documents",
+                nl: "Documenteert",
+              },
+              value: "documents",
+            },
+            {
+              label: {
+                en: "Is Compiled By",
+                nl: "Wordt Samengesteld Door",
+              },
+              value: "isCompiledBy",
+            },
+            {
+              label: {
+                en: "Compiles",
+                nl: "Stelt Samen",
+              },
+              value: "compiles",
+            },
+            {
+              label: {
+                en: "Is Variant Form Of",
+                nl: "Is Variant Vorm Van",
+              },
+              value: "isVariantFormOf",
+            },
+            {
+              label: {
+                en: "Is Original Form Of",
+                nl: "Is Originele Vorm Van",
+              },
+              value: "isOrignialFormOf",
+            },
+            {
+              label: {
+                en: "Is Identical To",
+                nl: "Is Identiek Aan",
+              },
+              value: "isIdenticalTo",
+            },
+            {
+              label: {
+                en: "Is Reviewed By",
+                nl: "Wordt Beoordeeld Door",
+              },
+              value: "isReviewedBy",
+            },
+            {
+              label: {
+                en: "Reviews",
+                nl: "Beoordeelt",
+              },
+              value: "reviews",
+            },
+            {
+              label: {
+                en: "Is Derived From",
+                nl: "Is Afgeleid Van",
+              },
+              value: "isDerivedFrom",
+            },
+            {
+              label: {
+                en: "Is Source Of",
+                nl: "Is Bron Van",
+              },
+              value: "isSourceOf",
+            },
+            {
+              label: {
+                en: "Requires",
+                nl: "Vereist",
+              },
+              value: "requires",
+            },
+            {
+              label: {
+                en: "Is Required By",
+                nl: "Is Vereist Door",
+              },
+              value: "isRequiredBy",
+            },
+            {
+              label: {
+                en: "Is Obsoleted By",
+                nl: "Wordt Verouderd Door",
+              },
+              value: "isObsoletedBy",
+            },
+            {
+              label: {
+                en: "Obsoletes",
+                nl: "Maakt Verouderd",
+              },
+              value: "obsoletes",
+            },
+            {
+              label: {
+                en: "Is Published In",
+                nl: "Wordt Gepubliceerd In",
+              },
+              value: "isPublishedIn",
+            },
+          ],
         },
         {
+          type: "text",
+          name: "relationIdentifier",
           label: {
-            en: "Cites",
-            nl: "Citeert",
+            en: "Identifier",
+            nl: "Identificatie",
           },
-          value: "cites",
-        },
-        {
-          label: {
-            en: "Is Supplement To",
-            nl: "Is Een Supplement Op",
+          required: true,
+          description: {
+            en: "Identifier of the related work (PID, URL, etc.)",
+            nl: "Identificatie van het gerelateerde werk (PID, URL, etc.)",
           },
-          value: "isSupplementTo",
-        },
-        {
-          label: {
-            en: "Is Supplemented By",
-            nl: "Wordt Aangevuld Door",
-          },
-          value: "isSupplementedBy",
-        },
-        {
-          label: {
-            en: "Is Continued By",
-            nl: "Wordt Voortgezet Door",
-          },
-          value: "isContinuedBy",
-        },
-        {
-          label: {
-            en: "Continues",
-            nl: "Gaat Verder",
-          },
-          value: "continues",
-        },
-        {
-          label: {
-            en: "Is Described By",
-            nl: "Wordt Beschreven Door",
-          },
-          value: "isDescribedBy",
-        },
-        {
-          label: {
-            en: "Describes",
-            nl: "Beschrijft",
-          },
-          value: "describes",
-        },
-        {
-          label: {
-            en: "Has Metadata",
-            nl: "Heeft Metadata",
-          },
-          value: "hasMetadata",
-        },
-        {
-          label: {
-            en: "Is Metadata For",
-            nl: "Is Metadata Voor",
-          },
-          value: "isMetadataFor",
-        },
-        {
-          label: {
-            en: "Is New Version Of",
-            nl: "Is Nieuwe Versie Van",
-          },
-          value: "isNewVersionOf",
-        },
-        {
-          label: {
-            en: "Is Previous Version Of",
-            nl: "Is Vorige Versie Van",
-          },
-          value: "isPreviousVersionOf",
-        },
-        {
-          label: {
-            en: "Is Part Of",
-            nl: "Is Onderdeel Van",
-          },
-          value: "isPartOf",
-        },
-        {
-          label: {
-            en: "Has Part",
-            nl: "Heeft Deel",
-          },
-          value: "hasPart",
-        },
-        {
-          label: {
-            en: "Is Referenced By",
-            nl: "Wordt Verwezen Door",
-          },
-          value: "isReferencedBy",
-        },
-        {
-          label: {
-            en: "References",
-            nl: "Verwijst",
-          },
-          value: "references",
-        },
-        {
-          label: {
-            en: "Is Documented By",
-            nl: "Wordt Gedocumenteerd Door",
-          },
-          value: "isDocumentedBy",
-        },
-        {
-          label: {
-            en: "Documents",
-            nl: "Documenteert",
-          },
-          value: "documents",
-        },
-        {
-          label: {
-            en: "Is Compiled By",
-            nl: "Wordt Samengesteld Door",
-          },
-          value: "isCompiledBy",
-        },
-        {
-          label: {
-            en: "Compiles",
-            nl: "Stelt Samen",
-          },
-          value: "compiles",
-        },
-        {
-          label: {
-            en: "Is Variant Form Of",
-            nl: "Is Variant Vorm Van",
-          },
-          value: "isVariantFormOf",
-        },
-        {
-          label: {
-            en: "Is Original Form Of",
-            nl: "Is Originele Vorm Van",
-          },
-          value: "isOrignialFormOf",
-        },
-        {
-          label: {
-            en: "Is Identical To",
-            nl: "Is Identiek Aan",
-          },
-          value: "isIdenticalTo",
-        },
-        {
-          label: {
-            en: "Is Reviewed By",
-            nl: "Wordt Beoordeeld Door",
-          },
-          value: "isReviewedBy",
-        },
-        {
-          label: {
-            en: "Reviews",
-            nl: "Beoordeelt",
-          },
-          value: "reviews",
-        },
-        {
-          label: {
-            en: "Is Derived From",
-            nl: "Is Afgeleid Van",
-          },
-          value: "isDerivedFrom",
-        },
-        {
-          label: {
-            en: "Is Source Of",
-            nl: "Is Bron Van",
-          },
-          value: "isSourceOf",
-        },
-        {
-          label: {
-            en: "Requires",
-            nl: "Vereist",
-          },
-          value: "requires",
-        },
-        {
-          label: {
-            en: "Is Required By",
-            nl: "Is Vereist Door",
-          },
-          value: "isRequiredBy",
-        },
-        {
-          label: {
-            en: "Is Obsoleted By",
-            nl: "Wordt Verouderd Door",
-          },
-          value: "isObsoletedBy",
-        },
-        {
-          label: {
-            en: "Obsoletes",
-            nl: "Maakt Verouderd",
-          },
-          value: "obsoletes",
-        },
-        {
-          label: {
-            en: "Is Published In",
-            nl: "Wordt Gepubliceerd In",
-          },
-          value: "isPublishedIn",
         },
       ],
     },


### PR DESCRIPTION
## Description

PR introduces new field that extends the relation field in Related work by specifying the identifier of the related work. The field now also turned into an repeatable group called Related Works.

## Related Issue(s)

Jira ticket [RDA-16](https://drivenbydata.atlassian.net/browse/RDA-16?atlOrigin=eyJpIjoiY2RmMDJlZGFkNzQxNDVhYjljZmE3ZDA1MDA1OWEyZmUiLCJwIjoiaiJ9)

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring (changes that neither fixes a bug nor adds a feature)
- [ ] Performance improvement (changes that improve existing functionality)
- [ ] Test update (changes that modify tests)
- [ ] Other (please describe):

## Checklist

- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.


[RDA-16]: https://drivenbydata.atlassian.net/browse/RDA-16?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ