### PR TITLE
Rda-19 | Add UN SDG type-ahead selector

### DIFF
--- a/apps/rda/src/config/formsections/coverage.ts
+++ b/apps/rda/src/config/formsections/coverage.ts
@@ -87,6 +87,21 @@ const section: InitialSectionType = {
       multiselect: true,
       allowFreeText: false,
     },
+    {
+      type: "autocomplete",
+      name: "keywordsSdg",
+      label: {
+        en:"UN Sustainable Development Goals",
+        nl: "UN Duurzame Ontwikkelingsdoelen",
+      },
+      required: true,
+      description: {
+        en: "Links to UN Sustainable Development Goals",
+        nl: "Links naar UN Duurzame Ontwikkelingsdoelen",
+      },
+      multiselect: true,
+      options: "un_sustainable_development_goals",
+    }
   ],
 };
 

--- a/packages/deposit/src/features/metadata/MetadataFields.tsx
+++ b/packages/deposit/src/features/metadata/MetadataFields.tsx
@@ -30,6 +30,7 @@ import {
   SshLicencesField,
   LanguagesField,
   BiodiversityField,
+  UnSustainableDevelopmentGoalsField,
 } from "./fields/AutocompleteAPIField";
 import AutocompleteField from "./fields/AutocompleteField";
 import TextField from "./fields/TextField";
@@ -119,6 +120,8 @@ const SingleField = memo(({ field, groupName, groupIndex }: SingleFieldProps) =>
               return <BiodiversityField {...(commonProps as CommonProps<AutocompleteFieldType>)} variant="vernacular" />;
             case "biodiversity_species_scientific":
               return <BiodiversityField {...(commonProps as CommonProps<AutocompleteFieldType>)} variant="scientific" />;
+            case "un_sustainable_development_goals":
+              return <UnSustainableDevelopmentGoalsField {...(commonProps as CommonProps<AutocompleteFieldType>)} />;
             default:
               return <AutocompleteField {...(commonProps as CommonProps<AutocompleteFieldType>)} />;
           }

--- a/packages/deposit/src/features/metadata/api/unsdg.ts
+++ b/packages/deposit/src/features/metadata/api/unsdg.ts
@@ -1,0 +1,29 @@
+import { createApi, fetchBaseQuery } from "@reduxjs/toolkit/dist/query/react";
+import { UnsdgResponse } from "../../../types/Api";
+
+export const unsdgApi = createApi({
+  reducerPath: "unsdg",
+  baseQuery: fetchBaseQuery({ baseUrl: "https://unstats.un.org/" }),
+  endpoints: (build) => ({
+    fetchUnsdg: build.query({
+      query: () => ({
+        url: "sdgapi/v1/sdg/Goal/List",
+        headers: { Accept: "application/json" },
+      }),
+      transformResponse: (response: UnsdgResponse[]) => {
+        return response.length > 0
+          ? {
+              response: response.map((item) => ({
+                label: item.title,
+                value: item.code,
+                idLabel: "UNSDG code",
+                id: item.code,
+              })),
+            }
+          : [];
+      },
+    }),
+  }),
+});
+
+export const { useFetchUnsdgQuery } = unsdgApi;

--- a/packages/deposit/src/features/metadata/fields/AutocompleteAPIField.tsx
+++ b/packages/deposit/src/features/metadata/fields/AutocompleteAPIField.tsx
@@ -41,6 +41,7 @@ import {
   useFetchRdaDomainQuery,
   useFetchRdaInterestGroupQuery,
 } from "../api/rdaApi";
+import { useFetchUnsdgQuery } from "../api/unsdg";
 
 /*
  *  Type ahead fields for different API endpoints
@@ -407,6 +408,24 @@ export const SheetsField = ({ field, groupName, groupIndex }: AutocompleteFieldP
   );
 };
 
+export const UnSustainableDevelopmentGoalsField = ({ field, groupName, groupIndex }: AutocompleteFieldProps) => {
+  // Fetch data right away
+  const { data, isFetching, isLoading } = useFetchUnsdgQuery<QueryReturnType>(null);
+  const newField = {
+    ...field,
+    options: data && data.response ? data.response : [],
+  };
+
+  return (
+    <AutocompleteField
+      field={newField}
+      groupName={groupName}
+      groupIndex={groupIndex}
+      isLoading={isLoading || isFetching}
+    />
+  );
+}
+
 export const MultiApiField = ({ field, groupName, groupIndex }: AutocompleteFieldProps) => {
   const dispatch = useAppDispatch();
   const { t } = useTranslation("metadata");
@@ -500,6 +519,10 @@ export const MultiApiField = ({ field, groupName, groupIndex }: AutocompleteFiel
       {multiApiValue  === "biodiversity_species_scientific" && (
         <BiodiversityField field={field} groupName={groupName}
           groupIndex={groupIndex} variant="scientific" />
+      )}
+      {multiApiValue === "un_sustainable_development_goals" && (
+        <UnSustainableDevelopmentGoalsField field={field} groupName={groupName}
+          groupIndex={groupIndex} />
       )}
     </Stack>
   );

--- a/packages/deposit/src/redux/store.ts
+++ b/packages/deposit/src/redux/store.ts
@@ -21,6 +21,7 @@ import { rdaApi } from "../features/metadata/api/rdaApi";
 import { wmsApi } from "../features/metadata/api/wms";
 import { biodiversityApi } from "../features/metadata/api/biodiversity";
 import { validateKeyApi } from "@dans-framework/user-auth";
+import { unsdgApi } from "../features/metadata/api/unsdg";
 
 export const store = configureStore({
   reducer: {
@@ -43,6 +44,7 @@ export const store = configureStore({
     [maptilerApi.reducerPath]: maptilerApi.reducer,
     [wmsApi.reducerPath]: wmsApi.reducer,
     [biodiversityApi.reducerPath]: biodiversityApi.reducer,
+    [unsdgApi.reducerPath]: unsdgApi.reducer,
     submit: submitReducer,
     deposit: depositReducer,
   },
@@ -65,6 +67,7 @@ export const store = configureStore({
       .concat(maptilerApi.middleware)
       .concat(wmsApi.middleware)
       .concat(biodiversityApi.middleware)
+      .concat(unsdgApi.middleware)
       .concat(errorLogger),
 });
 

--- a/packages/deposit/src/types/Api.ts
+++ b/packages/deposit/src/types/Api.ts
@@ -188,3 +188,10 @@ export interface BiodiversityItem {
 export interface BiodiversityResponse {
   resultSet: BiodiversityItem[];
 }
+
+export interface UnsdgResponse {
+  code: string;
+  title: string;
+  description: string;
+  uri: string;
+}

--- a/packages/deposit/src/types/MetadataFields.ts
+++ b/packages/deposit/src/types/MetadataFields.ts
@@ -229,7 +229,8 @@ export type TypeaheadAPI =
   | "sshLicences"
   | "languageList"
   | "biodiversity_species_scientific"
-  | "biodiversity_species_vernacular";
+  | "biodiversity_species_vernacular"
+  | "un_sustainable_development_goals";
 
 // Options that should be specified if Google Sheet API is used in Autocomplete
 interface SheetOptions {


### PR DESCRIPTION
## Description

This PR adds an new auto complete field for [UN sustainable development goals ](https://sdgs.un.org/goals) while also adding it to the coverage section of the RDA deposit form.

## Related Issue(s)

Jira ticket [RDA-19](https://drivenbydata.atlassian.net/browse/RDA-19?atlOrigin=eyJpIjoiNjU4ZDY1YTBhMjI4NDYwMDg5Njk0M2JhOWFhMzM5ZDciLCJwIjoiaiJ9)

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring (changes that neither fixes a bug nor adds a feature)
- [ ] Performance improvement (changes that improve existing functionality)
- [ ] Test update (changes that modify tests)
- [ ] Other (please describe):

## Checklist

- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.


[RDA-19]: https://drivenbydata.atlassian.net/browse/RDA-19?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ