### PR TITLE
RDA-20 | Add maintance and retirement plan text field for RDA

### DIFF
--- a/apps/rda/src/config/formsections/administrative.ts
+++ b/apps/rda/src/config/formsections/administrative.ts
@@ -83,6 +83,21 @@ const section: InitialSectionType = {
       options: "languageList",
       value: { label: "English", value: "en" },
     },
+    {
+      type: "text",
+      name: "maintenancePlan",
+      label: {
+        en: "Maintenance and Retirement Plan",
+        nl: "Onderhouds- en Bewaarplan",
+      },
+      multiline: true,
+      required: true,
+      fullWidth: true,
+      description: {
+        en: "Describe how this deposit will be maintained over time and under what conditions it will be retired.",
+        nl: "Beschrijf hoe dit deposit in de loop van de tijd zal worden onderhouden en onder welke voorwaarden het zal worden beëindigd.",
+      },
+    },
   ],
 };
 


### PR DESCRIPTION
## Description

PR adds a new field called *Maintenance and Retirement Plan*  in the RDA app under the administrative section.

## Related Issue(s)

Jira ticket [RDA-20](https://drivenbydata.atlassian.net/browse/RDA-20?atlOrigin=eyJpIjoiYTVhZTJlYmRiMzExNGZiMGIyMTEzNjJmM2Y1M2I4YzYiLCJwIjoiaiJ9)

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring (changes that neither fixes a bug nor adds a feature)
- [ ] Performance improvement (changes that improve existing functionality)
- [ ] Test update (changes that modify tests)
- [ ] Other (please describe):

## Checklist

- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.


[RDA-20]: https://drivenbydata.atlassian.net/browse/RDA-20?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ