### PR TITLE
RDA-22 | Add Zenodo communities selector

### DIFF
--- a/apps/rda/src/config/formsections/administrative.ts
+++ b/apps/rda/src/config/formsections/administrative.ts
@@ -84,6 +84,41 @@ const section: InitialSectionType = {
       value: { label: "English", value: "en" },
     },
     {
+      type: "autocomplete",
+      required: true,
+      label: {
+        en: "Zenodo Community",
+        nl: "Zenodo Community",
+      },
+      name: "zenodoCommunity",
+      description: {
+        en: "The Zenodo community to which the deposit belongs",
+        nl: "De Zenodo community waartoe het deposit behoort",
+      },
+      options: [
+        {
+          label: "Research Data Alliance",
+          value: "rda",
+          url: "https://zenodo.org/communities/rda",
+        },
+        // {
+        //   label: "Research Data Alliance - Related Documents",
+        //   value: "rda-related",
+        //   url: "https://zenodo.org/communities/rda-related",
+        // },
+        // {
+        //   label: "RDA TIGER",
+        //   value: "rda-tiger",
+        //   url: "https://zenodo.org/communities/rda-tiger",
+        // },
+      ],
+      value: {
+        label: "Research Data Alliance",
+        value: "rda",
+        url: "https://zenodo.org/communities/rda",
+      },
+    },
+    {
       type: "text",
       name: "maintenancePlan",
       label: {
@@ -91,7 +126,6 @@ const section: InitialSectionType = {
         nl: "Onderhouds- en Bewaarplan",
       },
       multiline: true,
-      required: true,
       fullWidth: true,
       description: {
         en: "Describe how this deposit will be maintained over time and under what conditions it will be retired.",


### PR DESCRIPTION
## Description

This PR adds an new autocomplete field in the administrative section of the RDA deposit form. The field allows the selection of an Zenodo community for the deposit to be added too.

The autocomplete is an whitelisted list that only allows few RDA related communities.

## Related Issue(s)

Jira Ticket [RDA-22](https://drivenbydata.atlassian.net/browse/RDA-22?atlOrigin=eyJpIjoiYjMxYWI0ZjEwYTJmNDUxMTljOTBjZWEyYmYyZTJjMmEiLCJwIjoiaiJ9)

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring (changes that neither fixes a bug nor adds a feature)
- [ ] Performance improvement (changes that improve existing functionality)
- [ ] Test update (changes that modify tests)
- [ ] Other (please describe):

## Checklist

- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.


[RDA-22]: https://drivenbydata.atlassian.net/browse/RDA-22?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ