### PR TITLE
RDA-23 | Allow multiple right holders

### DIFF
--- a/apps/rda/src/config/formsections/rights.ts
+++ b/apps/rda/src/config/formsections/rights.ts
@@ -8,20 +8,35 @@ const section: InitialSectionType = {
   },
   fields: [
     {
-      type: "autocomplete",
-      name: "rightsholder",
+      type: "group",
+      name: "rightsholders",
       label: {
-        en: "Rights holder",
-        nl: "Rechthebbende",
+        en: "Rights holders",
+        nl: "Rechthebbenden",
       },
-      required: true,
       description: {
-        en: "Name of the organisation or individual(s) owning the work",
-        nl: "Naam van de organisatie of personen die eigenaar zijn van het werk",
+        en: "The organisation or individual(s) owning the work",
+        nl: "De organisatie of personen die eigenaar zijn van het werk",
       },
-      deriveFrom: "firstAuthor",
-      multiApiValue: "orcid",
-      options: ["ror", "orcid"],
+      repeatable: true,
+      fields: [
+        {
+          type: "autocomplete",
+          name: "rightsholder",
+          label: {
+            en: "Rights holder",
+            nl: "Rechthebbende",
+          },
+          required: true,
+          description: {
+            en: "Name of the organisation or individual(s) owning the work",
+            nl: "Naam van de organisatie of personen die eigenaar zijn van het werk",
+          },
+          deriveFrom: "firstAuthor",
+          multiApiValue: "orcid",
+          options: ["ror", "orcid"],
+        },
+      ],
     },
     {
       type: "autocomplete",


### PR DESCRIPTION
## Description

This PR enables multiple right holders for the deposit while also refactoring the `derivedFrom` property to support groups.

## Related Issue(s)

Jira ticket [RDA-23](https://drivenbydata.atlassian.net/browse/RDA-23?atlOrigin=eyJpIjoiYWU2ZjhhNzVhNmY5NDU1Y2JmOTU3NTU2NDRlYWQ1ODQiLCJwIjoiaiJ9)

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Refactoring (changes that neither fixes a bug nor adds a feature)
- [ ] Performance improvement (changes that improve existing functionality)
- [ ] Test update (changes that modify tests)
- [ ] Other (please describe):

## Checklist

- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.


[RDA-23]: https://drivenbydata.atlassian.net/browse/RDA-23?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ