### PR TITLE
Fix date format and multi option in field structure

### DIFF
--- a/apps/rda/src/config/formsections/administrative.ts
+++ b/apps/rda/src/config/formsections/administrative.ts
@@ -34,7 +34,7 @@ const section: InitialSectionType = {
         en: "Date of creation of the deposit",
         nl: "Datum van aanmaak van het deposit",
       },
-      format: "DD-MM-YYYY HH:mm",
+      format: "DD-MM-YYYY",
       autofill: "dateNow",
       disabled: true,
     },
@@ -50,7 +50,7 @@ const section: InitialSectionType = {
         en: "Date of last modification of the deposit",
         nl: "Datum van laatste wijziging van het deposit",
       },
-      format: "DD-MM-YYYY HH:mm",
+      format: "DD-MM-YYYY",
       autofill: "dateNow",
     },
     {
@@ -65,7 +65,7 @@ const section: InitialSectionType = {
         en: "Date of availability of the deposit",
         nl: "Datum van beschikbaarheid van het deposit",
       },
-      format: "DD-MM-YYYY HH:mm",
+      format: "DD-MM-YYYY",
       autofill: "dateNow",
     },
     {

--- a/apps/rda/src/config/formsections/citation.ts
+++ b/apps/rda/src/config/formsections/citation.ts
@@ -59,7 +59,7 @@ const section: InitialSectionType = {
         en: "Date of publication",
         nl: "Datum van publicatie",
       },
-      format: "DD-MM-YYYY HH:mm",
+      format: "DD-MM-YYYY",
       autofill: "dateNow",
     },
     {

--- a/apps/rda/src/config/formsections/relations.ts
+++ b/apps/rda/src/config/formsections/relations.ts
@@ -28,7 +28,6 @@ const section: InitialSectionType = {
             nl: "Relatie",
           },
           required: true,
-          multiselect: true,
           description: {
             en: "Other PID's, publications, projects",
             nl: "Andere PID's, publicaties, projecten",


### PR DESCRIPTION
## Description

Some last minute changes to the RDA deposit form such as date type that Zenodo accepts and disable multi select at the relation type

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Refactoring (changes that neither fixes a bug nor adds a feature)
- [ ] Performance improvement (changes that improve existing functionality)
- [ ] Test update (changes that modify tests)
- [ ] Other (please describe):

## Checklist

- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.