### PR TITLE
Feature/resubmit diff hilite

### DIFF
--- a/apps/ohsmart/src/App.tsx
+++ b/apps/ohsmart/src/App.tsx
@@ -61,7 +61,7 @@ const App = () => {
                 path="user-submissions"
                 element={
                   <AuthRoute>
-                    <UserSubmissions targetCredentials={form.targetCredentials} />
+                    <UserSubmissions targetCredentials={form.targetCredentials} resubmit={true} />
                   </AuthRoute>
                 }
               />

--- a/docs/user-auth.md
+++ b/docs/user-auth.md
@@ -66,7 +66,7 @@ import { LoginButton } from "@dans-framework/user-auth";
 
 ## UserSubmissions
 
-TBD. Displays a current users metadata submissions. Needs to be a child of `<AuthRoute />`.
+Displays a current users metadata submissions. Needs to be a child of `<AuthRoute />`. 
 
 ```tsx
 import { UserSubmissions } from "@dans-framework/user-auth";
@@ -75,7 +75,11 @@ import { UserSubmissions } from "@dans-framework/user-auth";
   path="user-submissions"
   element={
     <AuthRoute>
-      <UserSubmissions />
+      <UserSubmissions 
+        depositSlug="/deposit" // a string, must point to the slug of the deposit page
+        targetCredentials={form.targetCredentials} // array of target objects, see form config in Deposit
+        resubmit={false} // set to true to enable resubmission of previously submitted forms
+      />
     </AuthRoute>
   }
 />;

--- a/packages/deposit/src/deposit/Deposit.tsx
+++ b/packages/deposit/src/deposit/Deposit.tsx
@@ -109,7 +109,10 @@ const Deposit = ({ config, page }: { config: FormConfig; page: Page }) => {
     }
     if (formAction?.action === "view") {
       dispatch(setFormDisabled(true));
-    } else {
+    } else if (formAction?.id !== serverFormData?.id) {
+      // reset the form status if another form is loaded from userSubmissions
+      dispatch(resetMetadataSubmitStatus());
+      dispatch(resetFilesSubmitStatus());
       dispatch(setFormDisabled(false));
     }
   }, [formAction, serverFormData]);
@@ -360,6 +363,7 @@ const ActionMessage = ({
               dispatch(resetFiles());
               dispatch(resetFilesSubmitStatus());
               dispatch(resetMetadataSubmitStatus());
+              dispatch(setFormDisabled(false));
               setDataMessage(false);
               clearFormActions();
             }}

--- a/packages/deposit/src/deposit/Deposit.tsx
+++ b/packages/deposit/src/deposit/Deposit.tsx
@@ -104,10 +104,12 @@ const Deposit = ({ config, page }: { config: FormConfig; page: Page }) => {
   // Load external form data
   useEffect(() => {
     if (formAction?.id && serverFormData?.md) {
+      // load the data
       dispatch(setExternalFormData({metadata: serverFormData.md.metadata, action: formAction.action, id: serverFormData['dataset-id']}));
       dispatch(addFiles(serverFormData.md["file-metadata"]));
     }
     if (formAction?.action === "view") {
+      // disable form if just viewing
       dispatch(setFormDisabled(true));
     } else if (formAction?.id !== serverFormData?.id) {
       // reset the form status if another form is loaded from userSubmissions
@@ -359,6 +361,7 @@ const ActionMessage = ({
           <Button
             variant="contained"
             onClick={() => {
+              // reset everything and enable form again
               dispatch(initForm(form));
               dispatch(resetFiles());
               dispatch(resetFilesSubmitStatus());

--- a/packages/deposit/src/features/files/filesSlice.ts
+++ b/packages/deposit/src/features/files/filesSlice.ts
@@ -10,8 +10,6 @@ export const filesSlice = createSlice({
   reducers: {
     // keep track of file selection
     addFiles: (state, action: PayloadAction<SelectedFile[]>) => {
-      console.log("adding");
-      console.log(action);
       state.push(...action.payload);
     },
     removeFile: (state, action: PayloadAction<SelectedFile>) => {
@@ -20,7 +18,6 @@ export const filesSlice = createSlice({
       );
     },
     setFileMeta: (state, action: PayloadAction<ReduxFileActions>) => {
-      console.log(action);
       // set extra metadata for this file: restricted status, role, processing, validity
       const file = state.find(
         (file: SelectedFile) => file.id === action.payload.id,

--- a/packages/deposit/src/features/submit/submitApi.ts
+++ b/packages/deposit/src/features/submit/submitApi.ts
@@ -91,7 +91,6 @@ export const submitApi = createApi({
         store.dispatch(setMetadataSubmitStatus("error"));
         // enable form again, so user can try and resubmit
         store.dispatch(setFormDisabled(false));
-        console.log(response)
         return {
           error: i18n.t("submit:submitMetadataError", {
             error: response.status === "FETCH_ERROR" ? i18n.t("submit:serverConnectionError") : response.status,

--- a/packages/user-auth/src/languages/locales/en/user.json
+++ b/packages/user-auth/src/languages/locales/en/user.json
@@ -53,5 +53,6 @@
 	"confirmDelete": "Confirm deletion",
 	"viewItemReadOnly": "As read only form",
 	"viewItemTarget": "On {{name}}",
-	"deleteSuccess": "Dataset succesfully deleted from server"
+	"deleteSuccess": "Dataset succesfully deleted from server",
+	"remoteChanges": "This dataset has been modified on the target server. Resubmitting this dataset will overwrite these changes. Viewing or copying this dataset in this app will not reflect the changes on the server."
 }

--- a/packages/user-auth/src/languages/locales/nl/user.json
+++ b/packages/user-auth/src/languages/locales/nl/user.json
@@ -53,5 +53,6 @@
 	"confirmDelete": "Bevestig verwijderen",
 	"viewItemReadOnly": "Als alleen-lezen form",
 	"viewItemTarget": "Op {{name}}",
-	"deleteSuccess": "Dataset succesvol verwijderd van server"
+	"deleteSuccess": "Dataset succesvol verwijderd van server",
+	"remoteChanges": "Deze dataset is aangepast op de doelserver. Het opnieuw indienen van deze dataset zal deze wijzigingen overschrijven. Het bekijken of kopiëren van deze dataset in deze app zal de wijzigingen op de server niet weergeven."
 }

--- a/packages/user-auth/src/types/index.ts
+++ b/packages/user-auth/src/types/index.ts
@@ -51,6 +51,7 @@ export interface TargetOutput {
   "display-name": string;
   "output-response": any;
   "repo-name": string;
+  diff: {} | { data: any };
 }
 
 export interface SubmissionResponse {
@@ -59,6 +60,7 @@ export interface SubmissionResponse {
   "release-version": ReleaseVersion;
   "saved-date": string | null;
   "submitted-date": string | null;
+  "legacy-form": boolean;
   targets: TargetOutput[];
   title: string;
 }

--- a/packages/user-auth/src/user/UserSubmissions.tsx
+++ b/packages/user-auth/src/user/UserSubmissions.tsx
@@ -297,7 +297,7 @@ const SubmissionList = ({
         type: "actions",
         align: "left",
         // adjust width for more icons. Add or remove 30 for an icon.
-        width: type === "draft" ? 125 : 165,
+        width: type === "draft" || !resubmit ? 125 : 165,
       },
       {
         field: "title",

--- a/packages/user-auth/src/user/UserSubmissions.tsx
+++ b/packages/user-auth/src/user/UserSubmissions.tsx
@@ -42,7 +42,8 @@ import LinearProgress from "@mui/material/LinearProgress";
 import Link from "@mui/material/Link";
 import EditIcon from "@mui/icons-material/Edit";
 import ContentCopyIcon from "@mui/icons-material/ContentCopy";
-// import ReplayIcon from "@mui/icons-material/Replay";
+import ErrorOutlineIcon from '@mui/icons-material/ErrorOutline';
+import ReplayIcon from "@mui/icons-material/Replay";
 import PendingIcon from "@mui/icons-material/Pending";
 import ErrorIcon from "@mui/icons-material/Error";
 import PreviewIcon from "@mui/icons-material/Preview";
@@ -192,8 +193,6 @@ const SubmissionList = ({
   const [toDelete, setToDelete] = useState<string>("");
   const [deleteSubmission] = useDeleteSubmissionMutation();
 
-  
-
   // useMemo to make sure columns don't change
   const columns = useMemo<GridColDef[]>(
     () => [
@@ -230,10 +229,10 @@ const SubmissionList = ({
                 id={params.row.id}
                 depositSlug={depositSlug}
                 status={params.row.status}
-                legacy={params.row["legacy-form"] || new Date(params.row.created) < new Date("2025-03-12")}
+                legacy={params.row.legacy || new Date(params.row.created) < new Date("2025-03-12")}
               />
             ),
-            /*type !== "draft" && (
+            type !== "draft" && (
               // Resubmit a form
               <Tooltip title={t("retryItem")} placement="bottom">
                 <GridActionsCellItem
@@ -250,7 +249,7 @@ const SubmissionList = ({
                   }}
                 />
               </Tooltip>
-            ),*/
+            ),
             <Tooltip title={t("copyItem")} placement="bottom">
               <GridActionsCellItem
                 icon={<ContentCopyIcon />}
@@ -292,7 +291,7 @@ const SubmissionList = ({
         type: "actions",
         align: "left",
         // adjust width for more icons. Add or remove 30 for an icon.
-        width: type === "draft" ? 125 : 125,
+        width: type === "draft" ? 125 : 165,
       },
       {
         field: "title",
@@ -400,6 +399,8 @@ const SubmissionList = ({
       id: d["dataset-id"],
       created: type === "draft" ? d["saved-date"] : d["submitted-date"],
       title: d["title"],
+      remoteChanges: d["targets"].some(t => t.diff && t.diff.hasOwnProperty("data")),
+      legacy: d["legacy-form"],
       ...(type === "published" ? { status: d["targets"] } : null),
     }));
 
@@ -495,7 +496,12 @@ const SingleTargetStatus = ({
 
   return (
     <>
-      <Stack direction="row" alignItems="center" pt={0.1} pb={0.1}>
+      <Stack direction="row" alignItems="center" pt={0.1} pb={0.1} spacing={0.5}>
+        {target.diff && target.diff.hasOwnProperty("data") && (
+          <Tooltip title={t("remoteChanges")} placement="left">
+            <ErrorOutlineIcon fontSize="small" color="warning" />
+          </Tooltip>
+        )}
         <Tooltip
           title={
             !target["deposit-status"] ? t("queue")
@@ -526,7 +532,7 @@ const SingleTargetStatus = ({
             <CheckCircleIcon fontSize="small" color="success" />
           : <PendingIcon fontSize="small" color="neutral" />}
         </Tooltip>
-        <Typography variant="body2" ml={1}>
+        <Typography variant="body2">
           {target["display-name"]}
         </Typography>
       </Stack>

--- a/packages/user-auth/src/user/UserSubmissions.tsx
+++ b/packages/user-auth/src/user/UserSubmissions.tsx
@@ -152,7 +152,6 @@ export const UserSubmissions = ({
             isLoading={isLoading}
             header={t("userSubmissionsDrafts")}
             depositSlug={depositSlug !== undefined ? depositSlug : "deposit"}
-            resubmit={resubmit}
           />
           <SubmissionList
             data={
@@ -169,6 +168,7 @@ export const UserSubmissions = ({
             isLoading={isLoading}
             header={t("userSubmissionsCompleted")}
             depositSlug={depositSlug !== undefined ? depositSlug : "deposit"}
+            resubmit={resubmit}
           />
         </Grid>
       </Grid>
@@ -243,6 +243,7 @@ const SubmissionList = ({
                 <GridActionsCellItem
                   icon={<ReplayIcon />}
                   label={t("retryItem")}
+                  disabled // disabled for now
                   onClick={() => {
                     dispatch(
                       setFormAction({

--- a/packages/user-auth/src/user/UserSubmissions.tsx
+++ b/packages/user-auth/src/user/UserSubmissions.tsx
@@ -77,10 +77,12 @@ const depositStatus: DepositStatus = {
 
 export const UserSubmissions = ({ 
   depositSlug, 
-  targetCredentials 
+  targetCredentials,
+  resubmit,
 }: { 
   depositSlug?: string;
   targetCredentials?: { repo: string; auth: string; authKey: string; }[];
+  resubmit?: boolean;
 }) => {
   const { t } = useTranslation("user");
   const siteTitle = useSiteTitle();
@@ -150,6 +152,7 @@ export const UserSubmissions = ({
             isLoading={isLoading}
             header={t("userSubmissionsDrafts")}
             depositSlug={depositSlug !== undefined ? depositSlug : "deposit"}
+            resubmit={resubmit}
           />
           <SubmissionList
             data={
@@ -179,12 +182,14 @@ const SubmissionList = ({
   header,
   type,
   depositSlug,
+  resubmit,
 }: {
   data: SubmissionResponse[];
   isLoading: boolean;
   header: string;
   type: "draft" | "published";
   depositSlug: string;
+  resubmit?: boolean;
 }) => {
   const { t, i18n } = useTranslation("user");
   const navigate = useNavigate();
@@ -232,7 +237,7 @@ const SubmissionList = ({
                 legacy={params.row.legacy || new Date(params.row.created) < new Date("2025-03-12")}
               />
             ),
-            type !== "draft" && (
+            type !== "draft" && resubmit && (
               // Resubmit a form
               <Tooltip title={t("retryItem")} placement="bottom">
                 <GridActionsCellItem


### PR DESCRIPTION
## Description

Added logic to enable resubmission of forms. Needs to be defined in the app, and is false by default (so no change for existing apps).

Added logic that shows if a submission has been edited on the target (and hence should not be edited/resubmitted anymore in the form). Definite logic (disable resubmit completely yes/no) should still be defined, right now it's just a warning.

Also fixed bugs regarding viewing and copying a form.

## Type of Change

- [X] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring (changes that neither fixes a bug nor adds a feature)
- [ ] Performance improvement (changes that improve existing functionality)
- [ ] Test update (changes that modify tests)
- [ ] Other (please describe):

## Checklist

- [X] I have performed a self-review of my own code.
- [X] I have commented my code, particularly in hard-to-understand areas.
- [X] I have made corresponding changes to the documentation.
- [X] My changes generate no new warnings.
