### PR TITLE
RDA 33 | PID option for field validation and RDA relation scheme type field removal

### DIFF
--- a/apps/rda/src/config/formsections/relations.ts
+++ b/apps/rda/src/config/formsections/relations.ts
@@ -29,8 +29,8 @@ const section: InitialSectionType = {
           },
           required: true,
           description: {
-            en: "Other PID's, publications, projects",
-            nl: "Andere PID's, publicaties, projecten",
+            en: "Relations to other PID's, publications, projects",
+            nl: "Relatie tot andere PID's, publicaties, projecten",
           },
           options: [
             {
@@ -267,117 +267,11 @@ const section: InitialSectionType = {
             nl: "Identificatie",
           },
           required: true,
+          validation: "pid",
           description: {
-            en: "Identifier of the related work (PID, URL, etc.)",
-            nl: "Identificatie van het gerelateerde werk (PID, URL, etc.)",
+            en: "Identifier of the related work (DOI, URL, etc.)",
+            nl: "Identificatie van het gerelateerde werk (DOI, URL, etc.)",
           },
-        },
-        {
-          type: "autocomplete",
-          name: "relationScheme",
-          label: {
-            en: "Scheme",
-            nl: "Schema",
-          },
-          required: true,
-          description: {
-            en: "Scheme of the related work identifier",
-            nl: "Schema van de identificatie van het gerelateerde werk",
-          },
-          options: [
-            {
-              label: "ARK",
-              value: "ark",
-            },
-            {
-              label: "arXiv",
-              value: "arxiv",
-            },
-            {
-              label: "Bibcode",
-              value: "ads",
-            },
-            {
-              label: "Crossref Funder ID",
-              value: "crossreffunderid",
-            },
-            {
-              label: "DOI",
-              value: "doi",
-            },
-            {
-              label: "EAN13",
-              value: "ean13",
-            },
-            {
-              label: "EISSN",
-              value: "eissn",
-            },
-            {
-              label: "GRID",
-              value: "grid",
-            },
-            {
-              label: "Handle",
-              value: "handle",
-            },
-            {
-              label: "IGSN",
-              value: "igsn",
-            },
-            {
-              label: "ISBN",
-              value: "isbn",
-            },
-            {
-              label: "ISNI",
-              value: "isni",
-            },
-            {
-              label: "ISSN",
-              value: "issn",
-            },
-            {
-              label: "ISTC",
-              value: "istc",
-            },
-            {
-              label: "LISSN",
-              value: "lissn",
-            },
-            {
-              label: "LSID",
-              value: "lsid",
-            },
-            {
-              label: "PMID",
-              value: "pmid",
-            },
-            {
-              label: "PURL",
-              value: "purl",
-            },
-            {
-              label: "UPC",
-              value: "upc",
-            },
-            {
-              label: "URL",
-              value: "url",
-            },
-            {
-              label: "URN",
-              value: "urn",
-            },
-            {
-              label: "W3ID",
-              value: "w3id",
-            },
-            {
-              label: "Other",
-              value: "other",
-            },
-          ],
         },
         {
           type: "autocomplete",

--- a/packages/deposit/src/features/metadata/metadataHelpers.ts
+++ b/packages/deposit/src/features/metadata/metadataHelpers.ts
@@ -21,6 +21,12 @@ export const validateData = (type: ValidationType, value: string): boolean => {
       return /^(https?|ftp):\/\/[^\s/$.?#]*\.[^\s]*$/.test(value.toLowerCase());
     case "github-uri":
       return /^https:\/\/github\.com\/.*$/.test(value.toLowerCase());
+    case "pid":
+      // Currently only checks for DOI and URL should potentially be expanded
+      // Might be better to revise some of the logic for this method to accept multiple validation types.
+      const doi = /^(https?:\/\/(dx\.)?doi\.org\/|doi:)?10\.\d{4,}([\.\-\/]?[a-zA-Z0-9_]+)+$/i.test(value.toLowerCase());
+      const url =  /^https?:\/\/(?:www\.)?[-a-zA-Z0-9@:%._\+~#=]{1,256}\.[a-zA-Z0-9()]{1,6}\b(?:[-a-zA-Z0-9()@:%_\+.~#?&\/=]*)$/.test(value.toLowerCase());
+      return doi || url;
     default:
       return true;
   }

--- a/packages/deposit/src/types/MetadataFields.ts
+++ b/packages/deposit/src/types/MetadataFields.ts
@@ -259,7 +259,7 @@ export interface OptionsType {
 }
 
 // Validation for text fields
-export type ValidationType = "email" | "uri" | "number" | "github-uri";
+export type ValidationType = "email" | "uri" | "number" | "github-uri" | "pid";
 
 // Format to return API response in, used by RTK's transformResponse
 export interface AutocompleteAPIFieldData<T = OptionsType[]> {


### PR DESCRIPTION
## Description

Removed the relation schema field from the relations section of the RDA app. Also introduced an new validation case for "pid"'s at the moment it just checks if it is an valid DOI or URL.

We probably want to extend this in the future or revise the logic for more granular validation.

## Related Issue(s)

[RDA 33](https://drivenbydata.atlassian.net/browse/RDA-33?atlOrigin=eyJpIjoiZGMxZTQ1ODZiNmE2NDdiMWJmODdlZWI1YWFmYmJjMTIiLCJwIjoiaiJ9)

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Refactoring (changes that neither fixes a bug nor adds a feature)
- [ ] Performance improvement (changes that improve existing functionality)
- [ ] Test update (changes that modify tests)
- [ ] Other (please describe):

## Checklist

- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
