### PR TITLE
feat(rdt-search-ui): add cutoff param for custom cutoff treshold

### DIFF
--- a/apps/rda/src/config/elasticSearch.tsx
+++ b/apps/rda/src/config/elasticSearch.tsx
@@ -39,6 +39,8 @@ export const elasticConfig: EndpointProps[] = [
             en: "Pathways",
             nl: "Paden",
           },
+          cutoff: 10,
+          size: 8,
           cols: 2,
           rows: 1,
         }}
@@ -101,6 +103,7 @@ export const elasticConfig: EndpointProps[] = [
             en: "Related institutions",
             nl: "Gerelateerde instellingen",
           },
+          cutoff: 10,
           cols: 2,
           rows: 1,
         }}
@@ -113,6 +116,7 @@ export const elasticConfig: EndpointProps[] = [
             en: "Working groups",
             nl: "Werkgroepen",
           },
+          cutoff: 10,
           cols: 2,
           rows: 1,
         }}
@@ -125,6 +129,7 @@ export const elasticConfig: EndpointProps[] = [
             en: "Interest groups",
             nl: "Interesse groepen",
           },
+          cutoff: 10,
           cols: 2,
           rows: 1,
         }}
@@ -137,7 +142,7 @@ export const elasticConfig: EndpointProps[] = [
             en: "Source",
             nl: "Bron",
           },
-          size: 10,
+          cutoff: 10,
           cols: 2,
           rows: 1,
         }}

--- a/packages/rdt-search-ui/src/facets/list/state.ts
+++ b/packages/rdt-search-ui/src/facets/list/state.ts
@@ -7,6 +7,7 @@ import { SortBy, SortDirection } from "../../enum";
 
 export interface ListFacetConfig extends BaseFacetConfig {
   size?: number;
+  cutoff?: number;
   sort?: ListFacetSort;
 }
 

--- a/packages/rdt-search-ui/src/facets/list/view/state.ts
+++ b/packages/rdt-search-ui/src/facets/list/view/state.ts
@@ -41,7 +41,7 @@ export const listFacetViewStates: Record<number, ListFacetViewState> = {
 export function getViewState(
   values: ListFacetValues,
   state: ListFacetState,
-  config: ListFacetConfig,
+  config: ListFacetConfig
 ) {
   if (values == null) return listFacetViewStates[0];
 
@@ -53,17 +53,19 @@ export function getViewState(
     else if (total === config.size!) return listFacetViewStates[5];
     else
       throw new Error(
-        `[viewState not set] Unexpected total (${total}) for query "${state.query}"`,
+        `[viewState not set] Unexpected total (${total}) for query "${state.query}"`
       );
   }
 
+  const customCutoff = config.cutoff ?? LIST_FACET_SCROLL_CUT_OFF;
+
   if (total < config.size!) {
     return listFacetViewStates[0];
-  } else if (total <= LIST_FACET_SCROLL_CUT_OFF) {
-    return state.size === total ?
-        listFacetViewStates[2]
+  } else if (total <= customCutoff) {
+    return state.size === total
+      ? listFacetViewStates[2]
       : listFacetViewStates[1];
-  } else if (total > LIST_FACET_SCROLL_CUT_OFF) {
+  } else if (total > customCutoff) {
     return listFacetViewStates[3];
   } else {
     throw new Error(`[viewState not set] unexpected total (${total})`);


### PR DESCRIPTION
## Description

This PR introduces an new parameter for the facet-list component. The `cutoff` parameter allows the list to specify an custom cutoff length to trigger the type-ahead view.

## Related Issue(s)

[RDA-52](https://drivenbydata.atlassian.net/browse/RDA-52)

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring (changes that neither fixes a bug nor adds a feature)
- [ ] Performance improvement (changes that improve existing functionality)
- [ ] Test update (changes that modify tests)
- [ ] Other (please describe):

## Checklist

- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.


[RDA-52]: https://drivenbydata.atlassian.net/browse/RDA-52?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ