### PR TITLE
RDA-56 | icon based view toggle for dashboard and search.

### DIFF
--- a/apps/rda/src/App.tsx
+++ b/apps/rda/src/App.tsx
@@ -40,8 +40,6 @@ const App = () => {
   const { i18n } = useTranslation();
   const { isEmbed } = useEmbedHandler();
 
-  console.log(isEmbed);
-
   const createElementByTemplate = (page: Page) => {
     switch (page.template) {
       case "dashboard":

--- a/apps/rda/src/config/elasticSearch.tsx
+++ b/apps/rda/src/config/elasticSearch.tsx
@@ -30,6 +30,7 @@ export const elasticConfig: EndpointProps[] = [
     fullTextHighlight: fieldConfig.fullTextHighlight,
     resultBodyComponent: Rda2Result,
     onClickResultPath: "record",
+    dashboardSearchIconToggle: true,
     dashboard: [
       <ListFacet
         config={{

--- a/apps/rda/src/config/pages/dashboard.ts
+++ b/apps/rda/src/config/pages/dashboard.ts
@@ -7,8 +7,8 @@ const page: Page = {
   template: "dashboard",
   inMenu: true,
   menuTitle: {
-    en: "Dashboard",
-    nl: "Dashboard",
+    en: "Dashboard/List",
+    nl: "Dashboard/Lijst",
   },
 };
 

--- a/apps/rda/src/config/pages/search.ts
+++ b/apps/rda/src/config/pages/search.ts
@@ -8,7 +8,7 @@ const page: Page = {
   },
   slug: "search",
   template: "search",
-  inMenu: true,
+  inMenu: false,
   menuTitle: {
     en: "Search",
     nl: "Zoeken",

--- a/packages/rdt-search-ui/src/context/props/index.ts
+++ b/packages/rdt-search-ui/src/context/props/index.ts
@@ -31,7 +31,7 @@ interface OptionalWithDefaultsSearchProps {
   excludeResultFields?: string[];
   onClickResult?: (
     result: any,
-    ev: React.MouseEvent<HTMLButtonElement>,
+    ev: React.MouseEvent<HTMLButtonElement>
   ) => void;
   resultFields?: string[];
   resultBodyProps?: Record<string, any>;
@@ -98,6 +98,7 @@ export interface EndpointProps extends EndpointBaseProps {
   resultBodyComponent: React.FC<ResultBodyProps>;
   fixedFacets?: FixedFacetsProps[];
   customColumns?: number;
+  dashboardSearchIconToggle?: boolean;
 }
 
 /**

--- a/packages/rdt-search-ui/src/icon-view-toggle.tsx
+++ b/packages/rdt-search-ui/src/icon-view-toggle.tsx
@@ -1,0 +1,70 @@
+import { Box, Button, SvgIcon, Tooltip } from "@mui/material";
+import { useNavigate } from "react-router-dom";
+
+interface IconViewToggleProps {
+  dashRoute: string;
+  resultRoute: string;
+}
+
+const IconViewToggle = ({ dashRoute, resultRoute }: IconViewToggleProps) => {
+  const navigate = useNavigate();
+
+  return (
+    <Box
+      sx={{
+        display: "flex",
+        gap: "1rem",
+        alignItems: "center",
+        justifyContent: "flex-end",
+        marginBottom: "2rem",
+      }}
+    >
+      <Tooltip title="Go to Dashboard View" arrow>
+        <Button
+          onClick={() => navigate(dashRoute)}
+          size="large"
+          aria-label="Dashboard View"
+        >
+          <SvgIcon
+            sx={{ width: "2.5rem", height: "2.5rem" }}
+            xmlns="http://www.w3.org/2000/svg"
+            fill="none"
+            viewBox="0 0 24 24"
+            strokeWidth={1.5}
+            stroke="currentColor"
+          >
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              d="M2.25 7.125C2.25 6.504 2.754 6 3.375 6h6c.621 0 1.125.504 1.125 1.125v3.75c0 .621-.504 1.125-1.125 1.125h-6a1.125 1.125 0 0 1-1.125-1.125v-3.75ZM14.25 8.625c0-.621.504-1.125 1.125-1.125h5.25c.621 0 1.125.504 1.125 1.125v8.25c0 .621-.504 1.125-1.125 1.125h-5.25a1.125 1.125 0 0 1-1.125-1.125v-8.25ZM3.75 16.125c0-.621.504-1.125 1.125-1.125h5.25c.621 0 1.125.504 1.125 1.125v2.25c0 .621-.504 1.125-1.125 1.125h-5.25a1.125 1.125 0 0 1-1.125-1.125v-2.25Z"
+            />
+          </SvgIcon>
+        </Button>
+      </Tooltip>
+      <Tooltip title="Go to Results View" arrow>
+        <Button
+          onClick={() => navigate(resultRoute)}
+          size="large"
+          aria-label="Results View"
+        >
+          <SvgIcon
+            sx={{ width: "2.5rem", height: "2.5rem" }}
+            xmlns="http://www.w3.org/2000/svg"
+            fill="none"
+            viewBox="0 0 24 24"
+            strokeWidth={1.5}
+            stroke="currentColor"
+          >
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              d="M8.25 6.75h12M8.25 12h12m-12 5.25h12M3.75 6.75h.007v.008H3.75V6.75Zm.375 0a.375.375 0 1 1-.75 0 .375.375 0 0 1 .75 0ZM3.75 12h.007v.008H3.75V12Zm.375 0a.375.375 0 1 1-.75 0 .375.375 0 0 1 .75 0Zm-.375 5.25h.007v.008H3.75v-.008Zm.375 0a.375.375 0 1 1-.75 0 .375.375 0 0 1 .75 0Z"
+            />
+          </SvgIcon>
+        </Button>
+      </Tooltip>
+    </Box>
+  );
+};
+
+export default IconViewToggle;

--- a/packages/rdt-search-ui/src/index.tsx
+++ b/packages/rdt-search-ui/src/index.tsx
@@ -38,11 +38,12 @@ import type { Result } from "./context/state/use-search/types";
 import { motion, AnimatePresence } from "framer-motion";
 import { FacetedSearchContext } from "./context/Provider";
 import LZString from "lz-string";
+import IconViewToggle from "./icon-view-toggle";
 
 export function FacetedSearch(props: ExternalSearchProps) {
   const [children, setChildren] = React.useState<React.ReactNode>(undefined);
   const [searchProps, setSearchProps] = React.useState<SearchProps | undefined>(
-    undefined,
+    undefined
   );
 
   React.useEffect(() => {
@@ -51,14 +52,11 @@ export function FacetedSearch(props: ExternalSearchProps) {
 
     const _children =
       // Make sure it is an element and not a string, number, ...
-      (
-        isValidElement(props.children) &&
-        // If children is a fragment, get the children of the fragment
-        props.children.type.toString() ===
-          Symbol.for("react.fragment").toString()
-      ) ?
-        props.children.props.children
-      : props.children;
+      isValidElement(props.children) &&
+      // If children is a fragment, get the children of the fragment
+      props.children.type.toString() === Symbol.for("react.fragment").toString()
+        ? props.children.props.children
+        : props.children;
 
     setChildren(_children);
   }, [props.children, props.url]);
@@ -88,7 +86,7 @@ export function FacetedSearch(props: ExternalSearchProps) {
       const value = (sp.style as any)[key];
       document.documentElement.style.setProperty(
         `--rdt-${camelCaseToKebabCase(key)}`,
-        value,
+        value
       );
     });
 
@@ -117,7 +115,7 @@ interface AppLoaderProps {
 function AppLoader({ children, controllers, searchProps }: AppLoaderProps) {
   // Check to see if there's a search query present in the url
   const queryParams = Object.fromEntries(
-    new URLSearchParams(window.location.search).entries(),
+    new URLSearchParams(window.location.search).entries()
   );
   const searchParams =
     queryParams.search &&
@@ -126,13 +124,13 @@ function AppLoader({ children, controllers, searchProps }: AppLoaderProps) {
   const storageState = deserializeObject(
     searchParams ||
       (sessionStorage.getItem(
-        `rdt-search-state-${window.location.origin}-${searchProps.url}`,
-      ) as string),
+        `rdt-search-state-${window.location.origin}-${searchProps.url}`
+      ) as string)
   );
   const [state, dispatch] = React.useReducer(
     searchStateReducer(controllers),
     // set storageState if available
-    { ...intialSearchState, ...storageState },
+    { ...intialSearchState, ...storageState }
   );
 
   useSearch({
@@ -170,7 +168,7 @@ function AppLoader({ children, controllers, searchProps }: AppLoaderProps) {
       serializeObject({
         facetFilters: state.facetFilters,
         query: state.query,
-      }),
+      })
     );
   }, [state.facetFilters, state.query]);
 
@@ -189,31 +187,30 @@ function AppLoader({ children, controllers, searchProps }: AppLoaderProps) {
               }}
             />
           )}
-          {
-            state.error ?
-              <Stack
-                justifyContent="center"
-                alignItems="center"
-                sx={{ height: "24rem" }}
-              >
-                <Stack>
-                  <Typography variant="h3">{t("error.header")}</Typography>
-                  <Typography paragraph>
-                    {t("error.p1", { message: state.error.message })}
-                  </Typography>
-                  <Typography paragraph>{t("error.p2")}</Typography>
-                </Stack>
+          {state.error ? (
+            <Stack
+              justifyContent="center"
+              alignItems="center"
+              sx={{ height: "24rem" }}
+            >
+              <Stack>
+                <Typography variant="h3">{t("error.header")}</Typography>
+                <Typography paragraph>
+                  {t("error.p1", { message: state.error.message })}
+                </Typography>
+                <Typography paragraph>{t("error.p2")}</Typography>
               </Stack>
-              // no error, show components
-            : <Component
-                controllers={controllers}
-                searchProps={searchProps}
-                searchState={state}
-              >
-                {children}
-              </Component>
-
-          }
+            </Stack>
+          ) : (
+            // no error, show components
+            <Component
+              controllers={controllers}
+              searchProps={searchProps}
+              searchState={state}
+            >
+              {children}
+            </Component>
+          )}
         </SearchStateContext.Provider>
       </SearchStateDispatchContext.Provider>
     </FacetControllersContext.Provider>
@@ -225,7 +222,7 @@ function AppLoader({ children, controllers, searchProps }: AppLoaderProps) {
  */
 function useControllers(children: React.ReactNode): FacetControllers {
   const [controllers, setControllers] = React.useState<FacetControllers>(
-    new Map(),
+    new Map()
   );
 
   React.useEffect(() => {
@@ -234,11 +231,11 @@ function useControllers(children: React.ReactNode): FacetControllers {
     // Initialise the facet controllers
     const facets = Children.map(
       children,
-      (child: any) => new child.type.controller(child.props.config),
+      (child: any) => new child.type.controller(child.props.config)
     );
 
     setControllers(
-      new Map(facets.map((f: FacetController<any, any, any>) => [f.ID, f])),
+      new Map(facets.map((f: FacetController<any, any, any>) => [f.ID, f]))
     );
   }, [children, controllers]);
 
@@ -265,7 +262,8 @@ export const FacetedWrapper = ({
   resultRoute?: string;
   children?: ReactNode;
 }) => {
-  const { config, endpoint, fixedFacets } = React.useContext(FacetedSearchContext);
+  const { config, endpoint, fixedFacets } =
+    React.useContext(FacetedSearchContext);
   const navigate = useNavigate();
   const currentConfig = config.find((e) => e.url === endpoint) as EndpointProps;
 
@@ -274,13 +272,18 @@ export const FacetedWrapper = ({
   return (
     <I18nextProvider i18n={i18nProvider}>
       <Container sx={{ pt: 4 }}>
+        {dashRoute &&
+          resultRoute &&
+          currentConfig.dashboardSearchIconToggle && (
+            <IconViewToggle dashRoute={dashRoute} resultRoute={resultRoute} />
+          )}
         {config.length > 1 && (
           // show selector if there's more than 1 endpoint
           <EndpointSelector />
         )}
-        {currentConfig.fixedFacets && currentConfig.fixedFacets.length > 0 &&
+        {currentConfig.fixedFacets && currentConfig.fixedFacets.length > 0 && (
           <FixedFacetSelector initialFixedFacets={currentConfig.fixedFacets} />
-        }
+        )}
         <AnimatePresence mode="wait" initial={false}>
           <motion.div
             key={currentConfig.url}
@@ -293,7 +296,11 @@ export const FacetedWrapper = ({
               fullTextFields={currentConfig.fullTextFields}
               fullTextHighlight={currentConfig.fullTextHighlight}
               onClickResult={(result: Result) =>
-                navigate(`/${currentConfig.onClickResultPath}/${encodeURIComponent(result.id)}`)
+                navigate(
+                  `/${currentConfig.onClickResultPath}/${encodeURIComponent(
+                    result.id
+                  )}`
+                )
               }
               ResultBodyComponent={currentConfig.resultBodyComponent}
               url={currentConfig.url}
@@ -306,7 +313,10 @@ export const FacetedWrapper = ({
               fixedFacets={fixedFacets}
             >
               {currentConfig?.dashboard.map((node, i) =>
-                React.cloneElement(node, { key: i, customColumns: currentConfig.customColumns }),
+                React.cloneElement(node, {
+                  key: i,
+                  customColumns: currentConfig.customColumns,
+                })
               )}
             </FacetedSearch>
           </motion.div>


### PR DESCRIPTION
## Description
This PR adds a new feature to the `rdt-search-ui` package. That allows to switch between the `dashRoute` and `resultRoute` by icons built in the `FacetedWrapper` component.

The component only renders if:
- a valid `dashRoute` **AND** `resultRoute` is given.
- The new `dashboardSearchIconToggle` property is true.

## Related Issue(s)
[RDA-56](https://drivenbydata.atlassian.net/browse/RDA-56)

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring (changes that neither fixes a bug nor adds a feature)
- [ ] Performance improvement (changes that improve existing functionality)
- [ ] Test update (changes that modify tests)
- [ ] Other (please describe):

## Checklist

- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.

## Screenshots

If applicable, add screenshots to help explain your problem or demonstrate the change.


[RDA-56]: https://drivenbydata.atlassian.net/browse/RDA-56?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ