### PR TITLE
Oh core/1 2

### DIFF
--- a/apps/ohsmart/src/config/formsections/coverage.ts
+++ b/apps/ohsmart/src/config/formsections/coverage.ts
@@ -53,8 +53,8 @@ const section: InitialSectionType = {
       noIndicator: true,
       repeatable: true,
       description: {
-        en: "Enter keywords that cannot be found in Getty AAT.",
-        nl: "Voer trefwoorden in die niet in Getty AAT te vinden zijn.",
+        en: "Enter keywords that cannot be found in Getty AAT and Wikidata. For more than one keyword, add additional input fields by clicking the plus icon.",
+        nl: "Voer trefwoorden in die niet in Getty AAT en Wikidata te vinden zijn. Voor meer dan één trefwoord, voeg extra invoervelden toe door op het plusicoon te klikken.",
       },
     },
     {

--- a/apps/ohsmart/src/config/formsections/coverage.ts
+++ b/apps/ohsmart/src/config/formsections/coverage.ts
@@ -10,18 +10,17 @@ const section: InitialSectionType = {
     {
       type: "autocomplete",
       label: {
-        en: "Subject keywords from Getty AAT or free text",
-        nl: "Onderwerpstrefwoorden uit Getty AAT of vrije tekst",
+        en: "Subject keywords from Getty AAT",
+        nl: "Onderwerpstrefwoorden uit Getty AAT",
       },
-      name: "subject_keywords",
+      name: "subject_keywords_aat",
       required: true,
       multiselect: true,
       description: {
-        en: "<p>Enter keywords that describe the content of your dataset in terms of artistic or architectural subject matter.</p><p>Keywords may either be selected from the Getty Art & Architecture Thesaurus (AAT), or entered as free text.</p>",
-        nl: "<p>Voer trefwoorden in die de inhoud van de dataset beschrijven voor wat betreft artistieke of architectonische onderwerpen.</p><p>Trefwoorden kunnen worden geselecteerd uit de Getty Art & Architecture Thesaurus (AAT) of worden ingevoerd als vrije tekst.</p>",
+        en: "Enter keywords that describe the content of your dataset in terms of artistic or architectural subject matter.",
+        nl: "Voer trefwoorden in die de inhoud van de dataset beschrijven voor wat betreft artistieke of architectonische onderwerpen.",
       },
       options: "gettyAat",
-      allowFreeText: true,
       value: [
         {
           label: "oral history (discipline)",
@@ -29,6 +28,34 @@ const section: InitialSectionType = {
           mandatory: true,
         },
       ],
+    },
+    {
+      type: "autocomplete",
+      label: {
+        en: "Subject keywords from Wikidata",
+        nl: "Onderwerpstrefwoorden uit Wikidata",
+      },
+      name: "subject_keywords_wikidata",
+      multiselect: true,
+      description: {
+        en: "Enter keywords that describe the content of your dataset in terms of artistic or architectural subject matter.",
+        nl: "Voer trefwoorden in die de inhoud van de dataset beschrijven voor wat betreft artistieke of architectonische onderwerpen.",
+      },
+      options: "wikidata",
+    },
+    {
+      type: "text",
+      label: {
+        en: "Other subject keywords",
+        nl: "Andere onderwerpstrefwoorden",
+      },
+      name: "subject_keywords_freetext",
+      noIndicator: true,
+      repeatable: true,
+      description: {
+        en: "Enter keywords that cannot be found in Getty AAT.",
+        nl: "Voer trefwoorden in die niet in Getty AAT te vinden zijn.",
+      },
     },
     {
       type: "autocomplete",

--- a/packages/deposit/src/features/metadata/MetadataFields.tsx
+++ b/packages/deposit/src/features/metadata/MetadataFields.tsx
@@ -30,6 +30,7 @@ import {
   LanguagesField,
   BiodiversityField,
   UnSustainableDevelopmentGoalsField,
+  WikidataField
 } from "./fields/AutocompleteAPIField";
 import AutocompleteField from "./fields/AutocompleteField";
 import TextField from "./fields/TextField";
@@ -120,6 +121,8 @@ const SingleField = memo(({ field, groupName, groupIndex, sx }: SingleFieldProps
               return <BiodiversityField {...(commonProps as CommonProps<AutocompleteFieldType>)} variant="scientific" />;
             case "un_sustainable_development_goals":
               return <UnSustainableDevelopmentGoalsField {...(commonProps as CommonProps<AutocompleteFieldType>)} />;
+            case "wikidata":
+              return <WikidataField {...(commonProps as CommonProps<AutocompleteFieldType>)} />;
             default:
               return <AutocompleteField {...(commonProps as CommonProps<AutocompleteFieldType>)} />;
           }

--- a/packages/deposit/src/features/metadata/api/datastations.ts
+++ b/packages/deposit/src/features/metadata/api/datastations.ts
@@ -28,6 +28,7 @@ export const datastationsApi = createApi({
         headers: { Accept: "application/json" },
       }),
       transformResponse: (response: DatastationsResponse, _meta, arg) => {
+        console.log(response)
         // Return an empty array when no results, which is what the Autocomplete field expects
         return response.results.length > 0 ?
             {

--- a/packages/deposit/src/features/metadata/api/wikidata.ts
+++ b/packages/deposit/src/features/metadata/api/wikidata.ts
@@ -17,7 +17,6 @@ export const wikidataApi = createApi({
         };
       },
       transformResponse: (response: WikidataResponse, _meta, arg) => {
-        console.log(response);
         // Return an empty array when no results, which is what the Autocomplete field expects
         return response["search-continue"] > 0 ?
             {

--- a/packages/deposit/src/features/metadata/api/wikidata.ts
+++ b/packages/deposit/src/features/metadata/api/wikidata.ts
@@ -13,7 +13,7 @@ export const wikidataApi = createApi({
     fetchWikidata: build.query({
       query: (content) => {
         return {
-          url: `api.php?action=wbsearchentities&format=json&type=item&language=en&search=${content}`
+          url: `api.php?action=wbsearchentities&format=json&type=item&language=en&origin=*&search=${content}`,
         };
       },
       transformResponse: (response: WikidataResponse, _meta, arg) => {

--- a/packages/deposit/src/features/metadata/api/wikidata.ts
+++ b/packages/deposit/src/features/metadata/api/wikidata.ts
@@ -1,0 +1,43 @@
+import { createApi, fetchBaseQuery } from "@reduxjs/toolkit/query/react";
+import type { WikidataResponse } from "../../../types/Api";
+import i18n from "../../../languages/i18n";
+
+/* NB: The Wikidata API does not allow CORS requests, so this API is not usable in the browser!!! */
+
+export const wikidataApi = createApi({
+  reducerPath: "wikidata",
+  baseQuery: fetchBaseQuery({
+    baseUrl: "https://www.wikidata.org/w",
+  }),
+  endpoints: (build) => ({
+    fetchWikidata: build.query({
+      query: (content) => {
+        return {
+          url: `api.php?action=wbsearchentities&format=json&type=item&language=en&search=${content}`
+        };
+      },
+      transformResponse: (response: WikidataResponse, _meta, arg) => {
+        console.log(response);
+        // Return an empty array when no results, which is what the Autocomplete field expects
+        return response["search-continue"] > 0 ?
+            {
+              arg: arg,
+              response: response["search"].map((item) => ({
+                label: item.label,
+                value: item.concepturi,
+                extraLabel: "Description",
+                extraContent: item.description,
+                idLabel: "ID",
+                id: item.id,
+              })),
+            }
+          : [];
+      },
+      transformErrorResponse: () => ({
+        error: i18n.t("metadata:apiFetchError", { api: "wikidata" }),
+      }),
+    }),
+  }),
+});
+
+export const { useFetchWikidataQuery } = wikidataApi;

--- a/packages/deposit/src/features/metadata/fields/AutocompleteAPIField.tsx
+++ b/packages/deposit/src/features/metadata/fields/AutocompleteAPIField.tsx
@@ -33,6 +33,7 @@ import { useFetchLicencesQuery } from "../api/licences";
 import { useFetchSshLicencesQuery } from "../api/sshLicences";
 import { useFetchLanguagesQuery } from "../api/languages";
 import { useFetchSpeciesQuery } from "../api/biodiversity";
+import { useFetchWikidataQuery } from "../api/wikidata";
 import {
   useFetchGorcQuery,
   useFetchRdaWorkingGroupQuery,
@@ -401,6 +402,30 @@ export const UnSustainableDevelopmentGoalsField = ({ field, groupName, groupInde
     />
   );
 }
+
+export const WikidataField = ({ field, groupName, groupIndex }: AutocompleteFieldProps) => {
+  const [inputValue, setInputValue] = useState<string>("");
+  const debouncedInputValue = useDebounce(inputValue, 500)[0];
+  // Fetch data on input change
+  const { data, isFetching, isLoading } =
+    useFetchWikidataQuery<QueryReturnType>(debouncedInputValue, {
+      skip: debouncedInputValue === "",
+    });
+
+  return (
+    <AutocompleteAPIField
+      field={field}
+      groupName={groupName}
+      groupIndex={groupIndex}
+      inputValue={inputValue}
+      setInputValue={setInputValue}
+      debouncedInputValue={debouncedInputValue}
+      data={data}
+      isLoading={isLoading}
+      isFetching={isFetching}
+    />
+  );
+};
 
 export const MultiApiField = ({ field, groupName, groupIndex }: AutocompleteFieldProps) => {
   const dispatch = useAppDispatch();

--- a/packages/deposit/src/languages/locales/en/metadata.json
+++ b/packages/deposit/src/languages/locales/en/metadata.json
@@ -27,6 +27,7 @@
   "multi-biodiversity_species_vernacular": "Vernacular name",
   "gettyAat": "Getty AAT",
   "geonames": "GeoNames",
+  "wikidata": "Wikidata",
   "elsst": "ELSST Thesaurus",
   "narcis": "NARCIS Classification of Scientific Disciplines",
   "dansCollections": "DANS Collections Thesaurus",

--- a/packages/deposit/src/languages/locales/nl/metadata.json
+++ b/packages/deposit/src/languages/locales/nl/metadata.json
@@ -23,6 +23,7 @@
   "multi-interest groups": "Interest Groups",
   "gettyAat": "Getty AAT",
   "geonames": "GeoNames",
+  "wikidata": "Wikidata",
   "elsst": "ELSST Thesaurus",
   "narcis": "NARCIS Classification of Scientific Disciplines",
   "dansCollections": "DANS Collections Thesaurus",

--- a/packages/deposit/src/redux/store.ts
+++ b/packages/deposit/src/redux/store.ts
@@ -19,6 +19,7 @@ import { maptilerApi } from "../features/metadata/api/maptiler";
 import { rdaApi } from "../features/metadata/api/rdaApi";
 import { wmsApi } from "../features/metadata/api/wms";
 import { biodiversityApi } from "../features/metadata/api/biodiversity";
+import { wikidataApi } from "../features/metadata/api/wikidata";
 import { validateKeyApi, userApi } from "@dans-framework/user-auth";
 import { unsdgApi } from "../features/metadata/api/unsdg";
 
@@ -44,6 +45,7 @@ export const store = configureStore({
     [wmsApi.reducerPath]: wmsApi.reducer,
     [biodiversityApi.reducerPath]: biodiversityApi.reducer,
     [unsdgApi.reducerPath]: unsdgApi.reducer,
+    [wikidataApi.reducerPath]: wikidataApi.reducer,
     submit: submitReducer,
     deposit: depositReducer,
   },
@@ -67,6 +69,7 @@ export const store = configureStore({
       .concat(wmsApi.middleware)
       .concat(biodiversityApi.middleware)
       .concat(unsdgApi.middleware)
+      .concat(wikidataApi.middleware)
       .concat(errorLogger),
 });
 

--- a/packages/deposit/src/types/Api.ts
+++ b/packages/deposit/src/types/Api.ts
@@ -181,3 +181,13 @@ export interface UnsdgResponse {
   description: string;
   uri: string;
 }
+
+export interface WikidataResponse {
+  search: {
+    id: string;
+    label: string;
+    description: string;
+    concepturi: string;
+  }[];
+  "search-continue": number;
+}

--- a/packages/deposit/src/types/MetadataFields.ts
+++ b/packages/deposit/src/types/MetadataFields.ts
@@ -229,7 +229,8 @@ export type TypeaheadAPI =
   | "languageList"
   | "biodiversity_species_scientific"
   | "biodiversity_species_vernacular"
-  | "un_sustainable_development_goals";
+  | "un_sustainable_development_goals"
+  | "wikidata";
 
 // Options that should be specified if Google Sheet API is used in Autocomplete
 interface SheetOptions {


### PR DESCRIPTION
## Description

Brings ohsmart uptodate with OHCore reqs 1 and 2: new wikidata typeahead field, ohsmart form config changes

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring (changes that neither fixes a bug nor adds a feature)
- [ ] Performance improvement (changes that improve existing functionality)
- [ ] Test update (changes that modify tests)
- [ ] Other (please describe):

## Checklist

- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.

