### PR TITLE
RDA-70 refactor(rda): renamed deposit and annotator slug

### DIFF
--- a/apps/rda/src/config/pages.ts
+++ b/apps/rda/src/config/pages.ts
@@ -1,9 +1,9 @@
 import dashboard from "./pages/dashboard";
-import deposit from "./pages/deposit";
+import publisher from "./pages/publisher";
 import search from "./pages/search";
 import record from "./pages/record";
 import extension from "./pages/rda-annotator";
 
-const pages = [dashboard, search, deposit, record, extension];
+const pages = [dashboard, search, publisher, record, extension];
 
 export default pages;

--- a/apps/rda/src/config/pages/publisher.ts
+++ b/apps/rda/src/config/pages/publisher.ts
@@ -1,14 +1,14 @@
 import type { Page } from "@dans-framework/pages";
 
 const page: Page = {
-  id: "deposit",
-  name: "Deposit",
-  slug: "deposit",
+  id: "publisher",
+  name: "Publisher",
+  slug: "publisher",
   template: "deposit",
   inMenu: true,
   menuTitle: {
-    en: "Deposit",
-    nl: "Indienen",
+    en: "Publisher",
+    nl: "Uitgever",
   },
 };
 

--- a/apps/rda/src/config/pages/rda-annotator.ts
+++ b/apps/rda/src/config/pages/rda-annotator.ts
@@ -1,17 +1,17 @@
 import type { Page } from "@dans-framework/pages";
 
 const page: Page = {
-  id: "rda-annotator",
+  id: "annotator",
   name: {
-    en: "RDA Annotator",
-    nl: "RDA Annotator",
+    en: "Annotator",
+    nl: "Annotator",
   },
-  slug: "rda-annotator",
+  slug: "annotator",
   template: "rda-annotator",
   inMenu: true,
   menuTitle: {
-    en: "RDA Annotator",
-    nl: "RDA Annotator",
+    en: "Annotator",
+    nl: "Annotator",
   },
 };
 


### PR DESCRIPTION
## Description

The `deposit` slug is now called `publisher` as well as its menu item. The same for the `rda annotator` which is now simply called `annotator`.

## Related Issue(s)

[RDA-70](https://drivenbydata.atlassian.net/browse/RDA-70)

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Refactoring (changes that neither fixes a bug nor adds a feature)
- [ ] Performance improvement (changes that improve existing functionality)
- [ ] Test update (changes that modify tests)
- [ ] Other (please describe):

## Checklist

- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.


[RDA-70]: https://drivenbydata.atlassian.net/browse/RDA-70?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ