### PR TITLE
RDA 69 - feat(rda): add sitetitle wrapper for better titles

### DIFF
--- a/apps/rda/index.html
+++ b/apps/rda/index.html
@@ -7,7 +7,7 @@
     <meta name="theme-color" content="#000000" />
     <meta
       name="description"
-      content="RDA"
+      content="RDA KB"
     />
     <link rel="apple-touch-icon" href="/logo192.png" />
     <!--

--- a/apps/rda/public/manifest.json
+++ b/apps/rda/public/manifest.json
@@ -1,6 +1,6 @@
 {
-  "short_name": "RDA",
-  "name": "RDA",
+  "short_name": "RDA KB",
+  "name": "RDA KB",
   "icons": [
     {
       "src": "favicon.ico",

--- a/apps/rda/src/App.tsx
+++ b/apps/rda/src/App.tsx
@@ -35,6 +35,7 @@ import SupportDrawer from "@dans-framework/support-drawer";
 import RDAAnnotator from "./pages/rda-annotator";
 import { useEmbedHandler } from "@dans-framework/utils";
 import { Link } from "@mui/material";
+import SiteTitleWrapper from "./config/sitetitle-wrapper";
 
 const App = () => {
   const { i18n } = useTranslation();
@@ -43,11 +44,23 @@ const App = () => {
   const createElementByTemplate = (page: Page) => {
     switch (page.template) {
       case "dashboard":
-        return <FacetedWrapper dashboard dashRoute="/" resultRoute="/search" />;
+        return (
+          <SiteTitleWrapper page={page}>
+            <FacetedWrapper dashboard dashRoute="/" resultRoute="/search" />
+          </SiteTitleWrapper>
+        );
       case "search":
-        return <FacetedWrapper dashRoute="/" resultRoute="/search" />;
+        return (
+          <SiteTitleWrapper page={page}>
+            <FacetedWrapper dashRoute="/" resultRoute="/search" />
+          </SiteTitleWrapper>
+        );
       case "record":
-        return <RdaRecord />;
+        return (
+          <SiteTitleWrapper page={page}>
+            <RdaRecord />
+          </SiteTitleWrapper>
+        );
       case "deposit":
         return (
           <AuthRoute>
@@ -55,7 +68,11 @@ const App = () => {
           </AuthRoute>
         );
       case "rda-annotator":
-        return <RDAAnnotator />;
+        return (
+          <SiteTitleWrapper page={page}>
+            <RDAAnnotator />
+          </SiteTitleWrapper>
+        );
       default:
         return <Generic {...page} />;
     }

--- a/apps/rda/src/config/pages/dashboard.ts
+++ b/apps/rda/src/config/pages/dashboard.ts
@@ -2,7 +2,10 @@ import type { Page } from "@dans-framework/pages";
 
 const page: Page = {
   id: "dashboard",
-  name: "Dashboard",
+  name: {
+    en: "Knowledge Base",
+    nl: "Kennisbank",
+  },
   slug: "/",
   template: "dashboard",
   inMenu: true,

--- a/apps/rda/src/config/pages/publisher.ts
+++ b/apps/rda/src/config/pages/publisher.ts
@@ -2,7 +2,10 @@ import type { Page } from "@dans-framework/pages";
 
 const page: Page = {
   id: "publisher",
-  name: "Publisher",
+  name: {
+    en: "Publisher",
+    nl: "Uitgever",
+  },
   slug: "publisher",
   template: "deposit",
   inMenu: true,

--- a/apps/rda/src/config/pages/record.ts
+++ b/apps/rda/src/config/pages/record.ts
@@ -2,7 +2,10 @@ import type { Page } from "@dans-framework/pages";
 
 const page: Page = {
   id: "record",
-  name: "Record",
+  name: {
+    en: "Knowledge Base Record",
+    nl: "Kennisbank Dossier",
+  },
   slug: "record/:id",
   template: "record",
   inMenu: false,

--- a/apps/rda/src/config/pages/search.ts
+++ b/apps/rda/src/config/pages/search.ts
@@ -3,8 +3,8 @@ import type { Page } from "@dans-framework/pages";
 const page: Page = {
   id: "search",
   name: {
-    en: "Search RDA",
-    nl: "Zoek RDA",
+    en: "Search Knowledge Base",
+    nl: "Zoek door Kennisbank",
   },
   slug: "search",
   template: "search",

--- a/apps/rda/src/config/siteTitle.ts
+++ b/apps/rda/src/config/siteTitle.ts
@@ -1,3 +1,3 @@
-const siteTitle = "RDA";
+const siteTitle = "RDA KB";
 
 export default siteTitle;

--- a/apps/rda/src/config/sitetitle-wrapper.tsx
+++ b/apps/rda/src/config/sitetitle-wrapper.tsx
@@ -1,0 +1,34 @@
+import { Page } from "@dans-framework/pages";
+import {
+  lookupLanguageString,
+  setSiteTitle,
+  useSiteTitle,
+} from "@dans-framework/utils";
+import { useEffect } from "react";
+import { useTranslation } from "react-i18next";
+
+/**
+ * Wrapper component that sets the site title based on the current page.
+ *
+ * @param children - React children to be wrapped
+ * @param page - The current page object containing the name used for the site title
+ * @returns JSX element that renders the children with the site title set
+ */
+const SiteTitleWrapper = ({
+  children,
+  page,
+}: {
+  children: React.ReactNode;
+  page: Page;
+}) => {
+  const { i18n } = useTranslation();
+  const siteTitle = useSiteTitle();
+
+  useEffect(() => {
+    setSiteTitle(siteTitle, lookupLanguageString(page.name, i18n.language));
+  }, [siteTitle, page.name]);
+
+  return <>{children}</>;
+};
+
+export default SiteTitleWrapper;


### PR DESCRIPTION
## Description

The commit adds a new component called `SiteTitleWrapper` that provides a additional way for easily changing the document title. Its usecase is for complex components that can't easily implement the logic themselfs.

## Related Issue(s)

[RDA-69](https://drivenbydata.atlassian.net/browse/RDA-69)

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Refactoring (changes that neither fixes a bug nor adds a feature)
- [ ] Performance improvement (changes that improve existing functionality)
- [ ] Test update (changes that modify tests)
- [ ] Other (please describe):

## Checklist

- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
