### PR TITLE
RDA 69 - feat(rda): add sitetitle wrapper for better titles

### DIFF
--- a/apps/rda/index.html
+++ b/apps/rda/index.html
@@ -7,7 +7,7 @@
     <meta name="theme-color" content="#000000" />
     <meta
       name="description"
-      content="RDA"
+      content="RDA KB"
     />
     <link rel="apple-touch-icon" href="/logo192.png" />
     <!--

--- a/apps/rda/public/manifest.json
+++ b/apps/rda/public/manifest.json
@@ -1,6 +1,6 @@
 {
-  "short_name": "RDA",
-  "name": "RDA",
+  "short_name": "RDA KB",
+  "name": "RDA KB",
   "icons": [
     {
       "src": "favicon.ico",

--- a/apps/rda/src/App.tsx
+++ b/apps/rda/src/App.tsx
@@ -35,6 +35,7 @@ import SupportDrawer from "@dans-framework/support-drawer";
 import RDAAnnotator from "./pages/rda-annotator";
 import { useEmbedHandler } from "@dans-framework/utils";
 import { Link } from "@mui/material";
+import SiteTitleWrapper from "./config/sitetitle-wrapper";
 
 const App = () => {
   const { i18n } = useTranslation();
@@ -43,11 +44,23 @@ const App = () => {
   const createElementByTemplate = (page: Page) => {
     switch (page.template) {
       case "dashboard":
-        return <FacetedWrapper dashboard dashRoute="/" resultRoute="/search" />;
+        return (
+          <SiteTitleWrapper page={page}>
+            <FacetedWrapper dashboard dashRoute="/" resultRoute="/search" />
+          </SiteTitleWrapper>
+        );
       case "search":
-        return <FacetedWrapper dashRoute="/" resultRoute="/search" />;
+        return (
+          <SiteTitleWrapper page={page}>
+            <FacetedWrapper dashRoute="/" resultRoute="/search" />
+          </SiteTitleWrapper>
+        );
       case "record":
-        return <RdaRecord />;
+        return (
+          <SiteTitleWrapper page={page}>
+            <RdaRecord />
+          </SiteTitleWrapper>
+        );
       case "deposit":
         return (
           <AuthRoute>
@@ -55,7 +68,11 @@ const App = () => {
           </AuthRoute>
         );
       case "rda-annotator":
-        return <RDAAnnotator />;
+        return (
+          <SiteTitleWrapper page={page}>
+            <RDAAnnotator />
+          </SiteTitleWrapper>
+        );
       default:
         return <Generic {...page} />;
     }

--- a/apps/rda/src/config/pages.ts
+++ b/apps/rda/src/config/pages.ts
@@ -1,9 +1,9 @@
 import dashboard from "./pages/dashboard";
-import deposit from "./pages/deposit";
+import publisher from "./pages/publisher";
 import search from "./pages/search";
 import record from "./pages/record";
 import extension from "./pages/rda-annotator";
 
-const pages = [dashboard, search, deposit, record, extension];
+const pages = [dashboard, search, publisher, record, extension];
 
 export default pages;

--- a/apps/rda/src/config/pages/dashboard.ts
+++ b/apps/rda/src/config/pages/dashboard.ts
@@ -2,7 +2,10 @@ import type { Page } from "@dans-framework/pages";
 
 const page: Page = {
   id: "dashboard",
-  name: "Dashboard",
+  name: {
+    en: "Knowledge Base",
+    nl: "Kennisbank",
+  },
   slug: "/",
   template: "dashboard",
   inMenu: true,

--- a/apps/rda/src/config/pages/publisher.ts
+++ b/apps/rda/src/config/pages/publisher.ts
@@ -1,14 +1,14 @@
 import type { Page } from "@dans-framework/pages";
 
 const page: Page = {
-  id: "deposit",
-  name: "Deposit",
-  slug: "deposit",
+  id: "publisher",
+  name: "Publisher",
+  slug: "publisher",
   template: "deposit",
   inMenu: true,
   menuTitle: {
-    en: "Deposit",
-    nl: "Indienen",
+    en: "Publisher",
+    nl: "Uitgever",
   },
 };
 

--- a/apps/rda/src/config/pages/publisher.ts
+++ b/apps/rda/src/config/pages/publisher.ts
@@ -2,7 +2,10 @@ import type { Page } from "@dans-framework/pages";
 
 const page: Page = {
   id: "publisher",
-  name: "Publisher",
+  name: {
+    en: "Publisher",
+    nl: "Uitgever",
+  },
   slug: "publisher",
   template: "deposit",
   inMenu: true,

--- a/apps/rda/src/config/pages/rda-annotator.ts
+++ b/apps/rda/src/config/pages/rda-annotator.ts
@@ -1,17 +1,17 @@
 import type { Page } from "@dans-framework/pages";
 
 const page: Page = {
-  id: "rda-annotator",
+  id: "annotator",
   name: {
-    en: "RDA Annotator",
-    nl: "RDA Annotator",
+    en: "Annotator",
+    nl: "Annotator",
   },
-  slug: "rda-annotator",
+  slug: "annotator",
   template: "rda-annotator",
   inMenu: true,
   menuTitle: {
-    en: "RDA Annotator",
-    nl: "RDA Annotator",
+    en: "Annotator",
+    nl: "Annotator",
   },
 };
 

--- a/apps/rda/src/config/pages/record.ts
+++ b/apps/rda/src/config/pages/record.ts
@@ -2,7 +2,10 @@ import type { Page } from "@dans-framework/pages";
 
 const page: Page = {
   id: "record",
-  name: "Record",
+  name: {
+    en: "Knowledge Base Record",
+    nl: "Kennisbank Dossier",
+  },
   slug: "record/:id",
   template: "record",
   inMenu: false,

--- a/apps/rda/src/config/pages/search.ts
+++ b/apps/rda/src/config/pages/search.ts
@@ -3,8 +3,8 @@ import type { Page } from "@dans-framework/pages";
 const page: Page = {
   id: "search",
   name: {
-    en: "Search RDA",
-    nl: "Zoek RDA",
+    en: "Search Knowledge Base",
+    nl: "Zoek door Kennisbank",
   },
   slug: "search",
   template: "search",

--- a/apps/rda/src/config/siteTitle.ts
+++ b/apps/rda/src/config/siteTitle.ts
@@ -1,3 +1,3 @@
-const siteTitle = "RDA";
+const siteTitle = "RDA KB";
 
 export default siteTitle;

--- a/apps/rda/src/config/sitetitle-wrapper.tsx
+++ b/apps/rda/src/config/sitetitle-wrapper.tsx
@@ -1,0 +1,34 @@
+import { Page } from "@dans-framework/pages";
+import {
+  lookupLanguageString,
+  setSiteTitle,
+  useSiteTitle,
+} from "@dans-framework/utils";
+import { useEffect } from "react";
+import { useTranslation } from "react-i18next";
+
+/**
+ * Wrapper component that sets the site title based on the current page.
+ *
+ * @param children - React children to be wrapped
+ * @param page - The current page object containing the name used for the site title
+ * @returns JSX element that renders the children with the site title set
+ */
+const SiteTitleWrapper = ({
+  children,
+  page,
+}: {
+  children: React.ReactNode;
+  page: Page;
+}) => {
+  const { i18n } = useTranslation();
+  const siteTitle = useSiteTitle();
+
+  useEffect(() => {
+    setSiteTitle(siteTitle, lookupLanguageString(page.name, i18n.language));
+  }, [siteTitle, page.name]);
+
+  return <>{children}</>;
+};
+
+export default SiteTitleWrapper;

--- a/packages/file-mapper/package.json
+++ b/packages/file-mapper/package.json
@@ -7,6 +7,7 @@
   "dependencies": {
     "@dans-framework/deposit": "workspace:*",
     "@dans-framework/utils": "workspace:*",
+    "@e965/xlsx": "^0.20.3",
     "@mui/icons-material": "^5.14.3",
     "@mui/material": "^5.16.7",
     "@reduxjs/toolkit": "^1.9.5",
@@ -19,8 +20,7 @@
     "react-i18next": "^13.0.3",
     "react-redux": "^8.1.2",
     "react-router-dom": "^6.14.2",
-    "uuid": "^9.0.0",
-    "xlsx": "^0.18.5"
+    "uuid": "^9.0.0"
   },
   "devDependencies": {
     "@dans-framework/pages": "workspace:*",

--- a/packages/file-mapper/src/features/FileMapper.tsx
+++ b/packages/file-mapper/src/features/FileMapper.tsx
@@ -98,6 +98,7 @@ const FileMapper = ({
         private: false,
         lastModified: 0,
         mapping: mapping,
+        mimeType: file.type,
       };
 
       // must initialize the form here, otherwise files will get overwritten

--- a/packages/file-mapper/src/features/SelectFile.tsx
+++ b/packages/file-mapper/src/features/SelectFile.tsx
@@ -42,6 +42,7 @@ const SelectFile = () => {
       name: files[0].name,
       size: files[0].size,
       url: URL.createObjectURL(files[0]),
+      type: files[0].type,
     };
 
     dispatch(setFile(serializedFile));

--- a/packages/file-mapper/src/features/SetMapping.tsx
+++ b/packages/file-mapper/src/features/SetMapping.tsx
@@ -46,7 +46,7 @@ export const SetMapping = () => {
 
   useEffect(() => {
     const loadXLSX = async () => {
-      const XLSX = await import("xlsx"); // Lazy load the library here
+      const XLSX = await import("@e965/xlsx"); // Lazy load the library here
 
       const reader = new FileReader();
       reader.onload = (event) => {

--- a/packages/file-mapper/src/features/fileMapperApi.ts
+++ b/packages/file-mapper/src/features/fileMapperApi.ts
@@ -15,7 +15,7 @@ export const darwinCoreApi = createApi({
       }),
       transformResponse: async (response, _meta, _arg) => {
         // Dynamically import XLSX
-        const XLSX = await import("xlsx"); // Lazy load the library here
+        const XLSX = await import("@e965/xlsx"); // Lazy load the library here
 
         // Convert CSV text string to JSON
         const workbook = XLSX.read(response, { type: "binary" });

--- a/packages/file-mapper/src/types/index.ts
+++ b/packages/file-mapper/src/types/index.ts
@@ -26,6 +26,7 @@ export interface SerializedFile {
   name: string;
   size: number;
   url: string;
+  type: string;
 }
 
 export type FileError = "tooManyRows";

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -809,6 +809,9 @@ importers:
       '@dans-framework/utils':
         specifier: workspace:*
         version: link:../utils
+      '@e965/xlsx':
+        specifier: ^0.20.3
+        version: 0.20.3
       '@mui/icons-material':
         specifier: ^5.14.3
         version: 5.16.8(@mui/material@5.16.8(@emotion/react@11.13.5(@types/react@18.2.15)(react@18.2.0))(@emotion/styled@11.13.5(@emotion/react@11.13.5(@types/react@18.2.15)(react@18.2.0))(@types/react@18.2.15)(react@18.2.0))(@types/react@18.2.15)(react-dom@18.3.1(react@18.2.0))(react@18.2.0))(@types/react@18.2.15)(react@18.2.0)
@@ -848,9 +851,6 @@ importers:
       uuid:
         specifier: ^9.0.0
         version: 9.0.1
-      xlsx:
-        specifier: ^0.18.5
-        version: 0.18.5
     devDependencies:
       '@dans-framework/pages':
         specifier: workspace:*
@@ -1363,6 +1363,11 @@ packages:
   '@babel/types@7.26.0':
     resolution: {integrity: sha512-Z/yiTPj+lDVnF7lWeKCIJzaIkI0vYO87dMpZ4bg4TDrFe4XXLFWL1TbXU27gBP3QccxV9mZICCrnjnYlJjXHOA==}
     engines: {node: '>=6.9.0'}
+
+  '@e965/xlsx@0.20.3':
+    resolution: {integrity: sha512-703RN/3OdsRD5mtse2HBX7Um7xwaP9tlswEG6svOtjqokXoX7rJdQj7DyabD2I+xk22RgaIIU+R6BHgkpZGB/w==}
+    engines: {node: '>=0.8'}
+    hasBin: true
 
   '@elastic/elasticsearch@8.16.2':
     resolution: {integrity: sha512-2ivc6uS97fbEeW4tNtg5mvh/Jy82ZLfcwQ1HhNhdYxyapNnQxIgZ83Zd8Ir+5jCPMDWKSYgwDb8t4GAINDDv2w==}
@@ -2344,10 +2349,6 @@ packages:
     engines: {node: '>=0.4.0'}
     hasBin: true
 
-  adler-32@1.3.1:
-    resolution: {integrity: sha512-ynZ4w/nUUv5rrsR8UUGoe1VC9hZj6V5hU9Qw1HlMDJGEJw5S7TfTErWTjMys6M7vr0YWcPqs3qAr4ss0nDfP+A==}
-    engines: {node: '>=0.8'}
-
   ajv@6.12.6:
     resolution: {integrity: sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==}
 
@@ -2464,10 +2465,6 @@ packages:
   caniuse-lite@1.0.30001686:
     resolution: {integrity: sha512-Y7deg0Aergpa24M3qLC5xjNklnKnhsmSyR/V89dLZ1n0ucJIFNs7PgR2Yfa/Zf6W79SbBicgtGxZr2juHkEUIA==}
 
-  cfb@1.2.2:
-    resolution: {integrity: sha512-KfdUZsSOw19/ObEWasvBP/Ac4reZvAGauZhs6S/gqNhXhI7cKwvlH7ulj+dOEYnca4bm4SGo8C1bTAQvnTjgQA==}
-    engines: {node: '>=0.8'}
-
   chalk-template@0.4.0:
     resolution: {integrity: sha512-/ghrgmhfY8RaSdeo43hNXxpoHAtxdbskUHjPpfqUWGttFgycUhYPGx3YZBCnUCvOa7Doivn1IZec3DEGFoMgLg==}
     engines: {node: '>=12'}
@@ -2497,10 +2494,6 @@ packages:
   clsx@2.1.1:
     resolution: {integrity: sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==}
     engines: {node: '>=6'}
-
-  codepage@1.15.0:
-    resolution: {integrity: sha512-3g6NUTPd/YtuuGrhMnOMRjFc+LJw/bnMp3+0r/Wcz3IXUuCosKRJvMphm5+Q+bvTVGcJJuRvVLuYba+WojaFaA==}
-    engines: {node: '>=0.8'}
 
   color-convert@2.0.1:
     resolution: {integrity: sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==}
@@ -2552,11 +2545,6 @@ packages:
 
   country-flag-icons@1.5.13:
     resolution: {integrity: sha512-4JwHNqaKZ19doQoNcBjsoYA+I7NqCH/mC/6f5cBWvdKzcK5TMmzLpq3Z/syVHMHJuDGFwJ+rPpGizvrqJybJow==}
-
-  crc-32@1.2.2:
-    resolution: {integrity: sha512-ROmzCKrTnOwybPcJApAA6WBWij23HVfGVNKqqrZpuyZOHqK2CwHSvpGuyt/UNNvaIjEd8X5IFGp4Mh+Ie1IHJQ==}
-    engines: {node: '>=0.8'}
-    hasBin: true
 
   cross-spawn@7.0.6:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
@@ -2823,10 +2811,6 @@ packages:
 
   for-each@0.3.3:
     resolution: {integrity: sha512-jqYfLp7mo9vIyQf8ykW2v7A+2N4QjeCeI5+Dz9XraiO1ign81wjiH7Fb9vSOWvQfNtmSa4H2RoQTrrXivdUZmw==}
-
-  frac@1.1.2:
-    resolution: {integrity: sha512-w/XBfkibaTl3YDqASwfDUqkna4Z2p9cFSr1aHDt0WoMTECnRfBOv2WArlZILlqgWlmdIlALXGpM2AOhEk5W3IA==}
-    engines: {node: '>=0.8'}
 
   framer-motion@10.18.0:
     resolution: {integrity: sha512-oGlDh1Q1XqYPksuTD/usb0I70hq95OUzmL9+6Zd+Hs4XV0oaISBa/UUMSjYiq6m8EUF32132mOJ8xVZS+I0S6w==}
@@ -3850,10 +3834,6 @@ packages:
     resolution: {integrity: sha512-NzNVhJDYpwceVVii8/Hu6DKfD2G+NrQHlS/V/qgv763EYudVwEcMQNxd2lh+0VrUByXN/oJkl5grOhYWvQUYiw==}
     engines: {node: '>=0.10.0'}
 
-  ssf@0.11.2:
-    resolution: {integrity: sha512-+idbmIXoYET47hH+d7dfm2epdOMUDjqcB4648sTZ+t2JwoyBFL/insLfB/racrDmsKB3diwsDA696pZMieAC5g==}
-    engines: {node: '>=0.8'}
-
   stack-utils@2.0.6:
     resolution: {integrity: sha512-XlkWvfIm6RmsWtNJx+uqtKLS8eqFbxUg0ZzLXqY0caEy9l7hruX8IpiDnjsLavoBgqCCR71TqWO8MaXYheJ3RQ==}
     engines: {node: '>=10'}
@@ -4207,26 +4187,13 @@ packages:
     engines: {node: ^16.13.0 || >=18.0.0}
     hasBin: true
 
-  wmf@1.0.2:
-    resolution: {integrity: sha512-/p9K7bEh0Dj6WbXg4JG0xvLQmIadrner1bi45VMJTfnbVHsc7yIajZyoSoK60/dtVBs12Fm6WkUI5/3WAVsNMw==}
-    engines: {node: '>=0.8'}
-
   word-wrap@1.2.5:
     resolution: {integrity: sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==}
     engines: {node: '>=0.10.0'}
 
-  word@0.3.0:
-    resolution: {integrity: sha512-OELeY0Q61OXpdUfTp+oweA/vtLVg5VDOXh+3he3PNzLGG/y0oylSOC1xRVj0+l4vQ3tj/bB1HVHv1ocXkQceFA==}
-    engines: {node: '>=0.8'}
-
   wordwrapjs@5.1.0:
     resolution: {integrity: sha512-JNjcULU2e4KJwUNv6CHgI46UvDGitb6dGryHajXTDiLgg1/RiGoPSDw4kZfYnwGtEXf2ZMeIewDQgFGzkCB2Sg==}
     engines: {node: '>=12.17'}
-
-  xlsx@0.18.5:
-    resolution: {integrity: sha512-dmg3LCjBPHZnQp5/F/+nnTa+miPJxUXB6vtk42YjBBKayDNagxGEeIdWApkYPOf3Z3pm3k62Knjzp7lMeTEtFQ==}
-    engines: {node: '>=0.8'}
-    hasBin: true
 
   xml-utils@1.10.1:
     resolution: {integrity: sha512-Dn6vJ1Z9v1tepSjvnCpwk5QqwIPcEFKdgnjqfYOABv1ngSofuAhtlugcUC3ehS1OHdgDWSG6C5mvj+Qm15udTQ==}
@@ -4381,6 +4348,8 @@ snapshots:
     dependencies:
       '@babel/helper-string-parser': 7.25.9
       '@babel/helper-validator-identifier': 7.25.9
+
+  '@e965/xlsx@0.20.3': {}
 
   '@elastic/elasticsearch@8.16.2':
     dependencies:
@@ -5348,8 +5317,6 @@ snapshots:
 
   acorn@8.14.0: {}
 
-  adler-32@1.3.1: {}
-
   ajv@6.12.6:
     dependencies:
       fast-deep-equal: 3.1.3
@@ -5485,11 +5452,6 @@ snapshots:
 
   caniuse-lite@1.0.30001686: {}
 
-  cfb@1.2.2:
-    dependencies:
-      adler-32: 1.3.1
-      crc-32: 1.2.2
-
   chalk-template@0.4.0:
     dependencies:
       chalk: 4.1.2
@@ -5520,8 +5482,6 @@ snapshots:
   clsx@1.2.1: {}
 
   clsx@2.1.1: {}
-
-  codepage@1.15.0: {}
 
   color-convert@2.0.1:
     dependencies:
@@ -5578,8 +5538,6 @@ snapshots:
       yaml: 1.10.2
 
   country-flag-icons@1.5.13: {}
-
-  crc-32@1.2.2: {}
 
   cross-spawn@7.0.6:
     dependencies:
@@ -5942,8 +5900,6 @@ snapshots:
   for-each@0.3.3:
     dependencies:
       is-callable: 1.2.7
-
-  frac@1.1.2: {}
 
   framer-motion@10.18.0(react-dom@18.3.1(react@18.2.0))(react@18.2.0):
     dependencies:
@@ -6943,10 +6899,6 @@ snapshots:
     dependencies:
       extend-shallow: 3.0.2
 
-  ssf@0.11.2:
-    dependencies:
-      frac: 1.1.2
-
   stack-utils@2.0.6:
     dependencies:
       escape-string-regexp: 2.0.0
@@ -7312,23 +7264,9 @@ snapshots:
     dependencies:
       isexe: 3.1.1
 
-  wmf@1.0.2: {}
-
   word-wrap@1.2.5: {}
 
-  word@0.3.0: {}
-
   wordwrapjs@5.1.0: {}
-
-  xlsx@0.18.5:
-    dependencies:
-      adler-32: 1.3.1
-      cfb: 1.2.2
-      codepage: 1.15.0
-      crc-32: 1.2.2
-      ssf: 0.11.2
-      wmf: 1.0.2
-      word: 0.3.0
 
   xml-utils@1.10.1: {}
 


### PR DESCRIPTION
## Description

The commit adds a new component called `SiteTitleWrapper` that provides a additional way for easily changing the document title. Its usecase is for complex components that can't easily implement the logic themselfs.

## Related Issue(s)

[RDA-69](https://drivenbydata.atlassian.net/browse/RDA-69)

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Refactoring (changes that neither fixes a bug nor adds a feature)
- [ ] Performance improvement (changes that improve existing functionality)
- [ ] Test update (changes that modify tests)
- [ ] Other (please describe):

## Checklist

- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.


[RDA-69]: https://drivenbydata.atlassian.net/browse/RDA-69?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ