### PR TITLE
RDA-80 - add return navigation on detail page and translation fixes

### DIFF
--- a/apps/rda/src/App.tsx
+++ b/apps/rda/src/App.tsx
@@ -33,7 +33,7 @@ import {
 import { Freshdesk } from "@dans-framework/freshdesk";
 import SupportDrawer from "@dans-framework/support-drawer";
 import RDAAnnotator from "./pages/rda-annotator";
-import { useEmbedHandler } from "@dans-framework/utils";
+import { lookupLanguageString, useEmbedHandler } from "@dans-framework/utils";
 import { Container, Link, Typography } from "@mui/material";
 import SiteTitleWrapper from "./config/sitetitle-wrapper";
 
@@ -64,7 +64,10 @@ const App = () => {
                         lineHeight: 1.1,
                       }}
                     >
-                      RDA Knowledge Base
+                      {lookupLanguageString(
+                        { en: "RDA Knowledge Base", nl: "RDA Kennisbank" },
+                        i18n.language
+                      )}
                     </Typography>
                     <Typography
                       component="p"
@@ -75,8 +78,13 @@ const App = () => {
                         lineHeight: 2,
                       }}
                     >
-                      The Knowledge Base is a suite of applications that helps
-                      users find, annotate, and publish RDA-related materials
+                      {lookupLanguageString(
+                        {
+                          en: "The Knowledge Base is a suite of applications that helps users find, annotate, and publish RDA-related materials",
+                          nl: "De Kennisbank is een suite van applicaties die gebruikers helpt bij het vinden, annoteren en publiceren van RDA-gerelateerde materialen",
+                        },
+                        i18n.language
+                      )}
                     </Typography>
                   </Box>
                 </Container>

--- a/apps/rda/src/pages/rda-annotator/index.tsx
+++ b/apps/rda/src/pages/rda-annotator/index.tsx
@@ -1,3 +1,4 @@
+import { lookupLanguageString } from "@dans-framework/utils";
 import {
   Box,
   Button,
@@ -8,15 +9,36 @@ import {
   Typography,
 } from "@mui/material";
 import ListItem from "@mui/material/ListItem";
+import { useTranslation } from "react-i18next";
 
 export default function RDAAnnotator() {
+  const { i18n } = useTranslation();
+
   const features = [
-    "Install the extension in your browser",
-    "Navigate to any web page with relevant research content",
-    "Select text you want to annotate",
-    "Add context with metadata like title, date, and resource type",
-    "Tag with vocabularies to connect to RDA working groups and interests",
-    "Submit your annotation to add it to the RDA Knowledge Base",
+    {
+      en: "Install the extension in your browser",
+      nl: "Installeer de extensie in uw browser",
+    },
+    {
+      en: "Navigate to any web page with relevant research content",
+      nl: "Navigeer naar een webpagina met relevante onderzoeksinhoud",
+    },
+    {
+      en: "Select text you want to annotate",
+      nl: "Selecteer de tekst die u wilt annoteren",
+    },
+    {
+      en: "Add context with metadata like title, date, and resource type",
+      nl: "Voeg context toe met metadata zoals titel, datum en type bron",
+    },
+    {
+      en: "Tag with vocabularies to connect to RDA working groups and interests",
+      nl: "Tag met vocabularies om verbinding te maken met RDA-werkgroepen en -interesses",
+    },
+    {
+      en: "Submit your annotation to add it to the RDA Knowledge Base",
+      nl: "Dien uw annotatie in om deze toe te voegen aan de RDA Knowledge Base",
+    },
   ];
 
   const onDownload = () => {
@@ -29,62 +51,146 @@ export default function RDAAnnotator() {
 
   return (
     <Container>
-      <Typography variant="h1">RDA Annotator Extension</Typography>
+      <Typography variant="h1">
+        {lookupLanguageString(
+          { en: "RDA Annotator Extension", nl: "RDA Annotator Extensie" },
+          i18n.language
+        )}
+      </Typography>
 
       <Typography marginTop={5} variant="h2">
-        What is the RDA Annotator?
+        {lookupLanguageString(
+          { en: "What is the RDA Annotator?", nl: "Wat is de RDA Annotator?" },
+          i18n.language
+        )}
       </Typography>
       <Typography>
-        The RDA Annotator is a browser extension that allows users to annotate
-        and tag web-based resources, which contextualises and categorises the
-        content. These annotations are then passed to the RDA Knowledge Base,
-        where it can be accessed by other RDA community members.
+        {lookupLanguageString(
+          {
+            en: "The RDA Annotator is a browser extension that allows users to annotate and tag web-based resources, which contextualises and categorises the content. These annotations are then passed to the RDA Knowledge Base, where it can be accessed by other RDA community members.",
+            nl: "De RDA Annotator is een browserextensie waarmee gebruikers webgebaseerde bronnen kunnen annoteren en taggen, waardoor de inhoud wordt gecontextualiseerd en gecategoriseerd. Deze annotaties worden vervolgens doorgegeven aan de RDA Knowledge Base, waar ze toegankelijk zijn voor andere leden van de RDA-gemeenschap.",
+          },
+          i18n.language
+        )}
         <br />
         <br />
         <span>
-          Download the Annotator using this link. For instructions on how to
-          install and use the tool, please refer to this <Link target="_blank" href="https://dans-knaw.github.io/RDA-TIGER-PDFs/3.3.7%20-%20Annotator%20Guidelines%20-%20v0.3.pdf">document</Link>
+          {lookupLanguageString(
+            {
+              en: "Download the Annotator using this link. For instructions on how to install and use the tool, please refer to this",
+              nl: "Download de Annotator met deze link. Voor instructies over hoe u de tool kunt installeren en gebruiken, verwijzen we naar dit",
+            },
+            i18n.language
+          )}
+          <Link
+            target="_blank"
+            href="https://dans-knaw.github.io/RDA-TIGER-PDFs/3.3.7%20-%20Annotator%20Guidelines%20-%20v0.3.pdf"
+          >
+            document
+          </Link>
         </span>
       </Typography>
 
       <Typography marginTop={5} variant="h2">
-        Why Use the RDA Annotator?
+        {lookupLanguageString(
+          {
+            en: "Why Use the RDA Annotator?",
+            nl: "Waarom de RDA Annotator gebruiken?",
+          },
+          i18n.language
+        )}
       </Typography>
       <List>
         <ListItem>
           <ListItemText>
-            <strong>Connect Research Resources:</strong> Easily link web content
-            to the RDA Graph and contribute to a growing knowledge network
+            <strong>
+              {lookupLanguageString(
+                {
+                  en: "Connect Research Resources:",
+                  nl: "Verbind Onderzoeksbronnen:",
+                },
+                i18n.language
+              )}
+            </strong>{" "}
+            <span>
+              {lookupLanguageString(
+                {
+                  en: "Easily link web content to the RDA Graph and contribute to a growing knowledge network",
+                  nl: "Verbind eenvoudig webinhoud met de RDA Graph en draag bij aan een groeiend kennisnetwerk",
+                },
+                i18n.language
+              )}
+            </span>
           </ListItemText>
         </ListItem>
         <ListItem>
           <ListItemText>
-            <strong>Contextual Tagging:</strong> Add meaningful metadata using
-            established RDA vocabularies
+            <strong>
+              {lookupLanguageString(
+                {
+                  en: "Contextual Tagging:",
+                  nl: "Contextuele Tagging:",
+                },
+                i18n.language
+              )}
+            </strong>{" "}
+            <span>
+              {lookupLanguageString(
+                {
+                  en: "Add meaningful metadata using established RDA vocabularies",
+                  nl: "Voeg betekenisvolle metadata toe met behulp van gevestigde RDA-woordenschatten",
+                },
+                i18n.language
+              )}
+            </span>
           </ListItemText>
         </ListItem>
         <ListItem>
           <ListItemText>
-            <strong>Improved Discoverability:</strong> Make important research
-            resources more findable for the entire research community
+            <strong>
+              {lookupLanguageString(
+                {
+                  en: "Improved Discoverability:",
+                  nl: "Verbeterde Vindbaarheid:",
+                },
+                i18n.language
+              )}
+            </strong>{" "}
+            <span>
+              {lookupLanguageString(
+                {
+                  en: "Make important research resources more findable for the entire research community",
+                  nl: "Zorg ervoor dat belangrijke onderzoeksbronnen beter vindbaar zijn voor de hele onderzoeksgemeenschap",
+                },
+                i18n.language
+              )}
+            </span>
           </ListItemText>
         </ListItem>
       </List>
 
       <Typography marginTop={5} variant="h2">
-        How Does It Work?
+        {lookupLanguageString(
+          { en: "How Does It Work?", nl: "Hoe Werkt Het?" },
+          i18n.language
+        )}
       </Typography>
 
       <List sx={{ listStyleType: "decimal", pl: 4 }}>
         {features.map((feature, index) => (
           <ListItem key={index} sx={{ display: "list-item", padding: "4px 0" }}>
-            <ListItemText primary={feature} />
+            <ListItemText
+              primary={lookupLanguageString(feature, i18n.language)}
+            />
           </ListItem>
         ))}
       </List>
 
       <Typography marginTop={5} variant="h2">
-        Getting Started
+        {lookupLanguageString(
+          { en: "Getting Started", nl: "Aan de Slag" },
+          i18n.language
+        )}
       </Typography>
 
       <Box
@@ -96,7 +202,10 @@ export default function RDAAnnotator() {
         }}
       >
         <Button onClick={onDownload} variant="contained" color="primary">
-          Chromium-based
+          {lookupLanguageString(
+            { en: "Chromium-based", nl: "Gebaseerd op Chromium" },
+            i18n.language
+          )}
         </Button>
       </Box>
     </Container>

--- a/apps/rda/src/pages/record/index.tsx
+++ b/apps/rda/src/pages/record/index.tsx
@@ -15,6 +15,8 @@ import {
 import React from "react";
 import { useParams } from "react-router-dom";
 import orcid from "../../config/images/orcid.png";
+import { lookupLanguageString } from "@dans-framework/utils";
+import { useTranslation } from "react-i18next";
 
 interface Individual {
   fullName: string;
@@ -225,6 +227,7 @@ export function RdaRecord() {
   const endpoint = getCurrentEndpoint();
 
   const theme = useTheme();
+  const { i18n } = useTranslation();
   const isSmUp = useMediaQuery(theme.breakpoints.up("sm"));
 
   React.useEffect(() => {
@@ -237,7 +240,10 @@ export function RdaRecord() {
 
   const items = [
     {
-      label: "Contributors",
+      label: lookupLanguageString(
+        { en: "Contributors", nl: "Bijdragers" },
+        i18n.language
+      ),
       value: record.individuals
         ? record.individuals.map((i) => (
             <React.Fragment key={i.identifier + i.fullName}>
@@ -251,7 +257,10 @@ export function RdaRecord() {
         : [],
     },
     {
-      label: "Pathways",
+      label: lookupLanguageString(
+        { en: "Pathways", nl: "Paden" },
+        i18n.language
+      ),
       value: record.pathways
         ? record.pathways.map((p) => (
             <Typography
@@ -265,7 +274,10 @@ export function RdaRecord() {
         : [],
     },
     {
-      label: "Interest Groups",
+      label: lookupLanguageString(
+        { en: "Interest Groups", nl: "Belangengroepen" },
+        i18n.language
+      ),
       value: record.interest_groups
         ? record.interest_groups.map((ig) => (
             <Typography key={ig.url} variant="body2" sx={{ color: "#374151" }}>
@@ -275,7 +287,10 @@ export function RdaRecord() {
         : [],
     },
     {
-      label: "Working Groups",
+      label: lookupLanguageString(
+        { en: "Working Groups", nl: "Werkgroepen" },
+        i18n.language
+      ),
       value: record.working_groups
         ? record.working_groups.map((wg) => (
             <Typography key={wg.url} variant="body2" sx={{ color: "#374151" }}>
@@ -285,7 +300,10 @@ export function RdaRecord() {
         : [],
     },
     {
-      label: "GORC Elements",
+      label: lookupLanguageString(
+        { en: "GORC Elements", nl: "GORC elementen" },
+        i18n.language
+      ),
       value: record.gorc_elements
         ? record.gorc_elements.map((ge) => (
             <Typography
@@ -299,7 +317,10 @@ export function RdaRecord() {
         : [],
     },
     {
-      label: "GORC Attributes",
+      label: lookupLanguageString(
+        { en: "GORC Attributes", nl: "GORC attributen" },
+        i18n.language
+      ),
       value: record.gorc_attributes
         ? record.gorc_attributes.map((ga) => (
             <Typography
@@ -313,7 +334,10 @@ export function RdaRecord() {
         : [],
     },
     {
-      label: "Domains",
+      label: lookupLanguageString(
+        { en: "Domains", nl: "Domeinen" },
+        i18n.language
+      ),
       value: record.disciplines
         ? record.disciplines.map((d) => (
             <Typography key={d.uuid} variant="body2" sx={{ color: "#374151" }}>
@@ -360,8 +384,10 @@ export function RdaRecord() {
           : [],
     },
     {
-
-      label: "Access URLs",
+      label: lookupLanguageString(
+        { en: "Access URLs", nl: "Toegang URL's" },
+        i18n.language
+      ),
       value: [
         <AccessUrls
           key="access-urls"
@@ -376,6 +402,35 @@ export function RdaRecord() {
 
   return (
     <Container sx={{ mt: 6 }}>
+      <Link
+        href="/search"
+        underline="none"
+        sx={{ display: "flex", alignItems: "center", mb: 3 }}
+      >
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          fill="none"
+          viewBox="0 0 24 24"
+          strokeWidth={1.5}
+          stroke="currentColor"
+          style={{ width: 16, height: 16, color: "#4F8E31" }}
+        >
+          <path
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            d="M6.75 15.75 3 12m0 0 3.75-3.75M3 12h18"
+          />
+        </svg>
+        <Typography
+          variant="body2"
+          sx={{ color: "#4F8E31", fontWeight: 500, ml: 0.5 }}
+        >
+          {lookupLanguageString(
+            { en: "Return to search", nl: "Terug naar zoeken" },
+            i18n.language
+          )}
+        </Typography>
+      </Link>
       <Typography
         variant="subtitle1"
         sx={{ color: "#111827", fontWeight: 600 }}
@@ -415,7 +470,13 @@ export function RdaRecord() {
       )}
 
       <Typography variant="body2" color="#6b7280" sx={{ mt: 3 }}>
-        Deposit metadata and status
+        {lookupLanguageString(
+          {
+            en: "Deposit metadata and status",
+            nl: "Depositeren metadata en status",
+          },
+          i18n.language
+        )}
       </Typography>
 
       <List disablePadding sx={{ mt: 3 }}>


### PR DESCRIPTION
## Description

1. The commits adds a navigation items on the detail pages so user can navigate back to the search page without using the browsers navigation.
2. There where some texts that where not being translated and now are.

## Related Issue(s)

[RDA-80](https://drivenbydata.atlassian.net/browse/RDA-80)

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring (changes that neither fixes a bug nor adds a feature)
- [ ] Performance improvement (changes that improve existing functionality)
- [ ] Test update (changes that modify tests)
- [ ] Other (please describe):

## Checklist

- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.


[RDA-80]: https://drivenbydata.atlassian.net/browse/RDA-80?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ