### PR TITLE
Deployment of JSX support for generic page and ticket RDA-73

### DIFF
--- a/apps/rda/src/config/footer.ts
+++ b/apps/rda/src/config/footer.ts
@@ -65,7 +65,7 @@ const footer: Footer = {
             en: "Disclaimer",
             nl: "Disclaimer",
           },
-          link: "",
+          link: "/disclaimer",
         },
         {
           name: {

--- a/apps/rda/src/config/pages.ts
+++ b/apps/rda/src/config/pages.ts
@@ -3,7 +3,8 @@ import publisher from "./pages/publisher";
 import search from "./pages/search";
 import record from "./pages/record";
 import extension from "./pages/rda-annotator";
+import disclaimer from "./pages/footer/disclaimer";
 
-const pages = [dashboard, search, publisher, record, extension];
+const pages = [dashboard, search, publisher, record, extension, disclaimer];
 
 export default pages;

--- a/apps/rda/src/config/pages/footer/disclaimer.tsx
+++ b/apps/rda/src/config/pages/footer/disclaimer.tsx
@@ -1,0 +1,151 @@
+import type { Page } from "@dans-framework/pages";
+import { Box, Link, Typography } from "@mui/material";
+
+const page: Page = {
+  id: "disclaimer",
+  name: "Disclaimer",
+  slug: "disclaimer",
+  template: "generic",
+  inMenu: false,
+  content: {
+    en: (
+      <Box
+        sx={{
+          maxWidth: 900,
+          mx: "auto",
+          py: 8,
+          px: 3,
+          fontFamily: "system-ui, -apple-system, BlinkMacSystemFont",
+        }}
+      >
+        <Box mb={4}>
+          <Typography variant="h4" component="h2" gutterBottom>
+            RDA TIGER Output Services Disclaimer
+          </Typography>
+          <Typography variant="body1" paragraph>
+            The work of RDA TIGER is done in close collaboration with the
+            Research Data Alliance (RDA). However, the RDA is in no way
+            responsible for RDA TIGER outputs and services, including those
+            described here, and provides no guarantees for their use and content
+            (in particular, any user-generated content).
+          </Typography>
+          <Typography variant="body1" paragraph>
+            The use of the RDA Logo is a registered trademark of the Research
+            Data Alliance Foundation, the use of which is permitted the project
+            under the{" "}
+            <Link href="https://www.rd-alliance.org/rda-endorsement-and-logo-usage-guidelines/">
+              Usage Guidelines
+            </Link>{" "}
+            available on the RDA Website. The EOSC logo is copyrighted by the
+            EOSC Association, and the use of the logo for co-branding by
+            EOSC-funded projects is permitted under the EOSC Association's{" "}
+            <Link href="https://www.eosc.eu/sites/default/files/2022-09/EOSC%20Co-Branding%20Guidelines%20for%20HE%20INFRAEOSC%20Projects_HR.pdf">
+              co-branding guidelines
+            </Link>
+            .
+          </Typography>
+        </Box>
+        <Box
+          sx={{
+            borderTop: 1,
+            borderColor: "grey.300",
+            pt: 2,
+            mt: 6,
+            display: "flex",
+            flexDirection: { xs: "column", sm: "row" },
+            justifyContent: "space-between",
+            gap: 1,
+          }}
+        >
+          <Typography variant="caption" sx={{ display: "block" }}>
+            Effective Date: July, 2025
+          </Typography>
+          <Typography
+            variant="caption"
+            sx={{ display: "block", textAlign: { xs: "left", sm: "right" } }}
+          >
+            © RDA Tiger
+          </Typography>
+        </Box>
+      </Box>
+    ),
+    nl: (
+      <Box
+        sx={{
+          maxWidth: 900,
+          mx: "auto",
+          py: 8,
+          px: 3,
+          fontFamily: "system-ui, -apple-system, BlinkMacSystemFont",
+        }}
+      >
+        <Typography
+          variant="h3"
+          component="h1"
+          gutterBottom
+          sx={{ fontFamily: "serif", fontWeight: 600, mb: 1 }}
+        >
+          Disclaimer
+        </Typography>
+        <Box mb={4}>
+          <Typography
+            variant="h5"
+            component="h2"
+            gutterBottom
+            sx={{ fontFamily: "serif" }}
+          >
+            RDA TIGER / Research Data Alliance
+          </Typography>
+          <Typography variant="body1" paragraph>
+            Het werk van RDA TIGER wordt in nauwe samenwerking met de Research
+            Data Alliance (RDA) uitgevoerd. De RDA is echter op geen enkele
+            wijze verantwoordelijk voor de resultaten en diensten van RDA TIGER,
+            inclusief de hier beschreven diensten, en biedt geen garanties voor
+            het gebruik en de inhoud ervan (in het bijzonder
+            gebruikersgegenereerde inhoud).
+          </Typography>
+          <Typography variant="body1" paragraph>
+            Het gebruik van het RDA-logo is een geregistreerd handelsmerk van de
+            Research Data Alliance Foundation, waarvan het gebruik door het
+            project is toegestaan onder de{" "}
+            <Link href="https://www.rd-alliance.org/rda-endorsement-and-logo-usage-guidelines/">
+              Gebruikersrichtlijnen
+            </Link>{" "}
+            beschikbaar op de RDA-website. Het EOSC-logo is auteursrechtelijk
+            beschermd door de EOSC Association, en het gebruik van het logo voor
+            co-branding door EOSC-gesubsidieerde projecten is toegestaan onder
+            de{" "}
+            <Link href="https://www.eosc.eu/sites/default/files/2022-09/EOSC%20Co-Branding%20Guidelines%20for%20HE%20INFRAEOSC%20Projects_HR.pdf">
+              co-branding richtlijnen
+            </Link>{" "}
+            van de EOSC Association.
+          </Typography>
+        </Box>
+        <Box
+          sx={{
+            borderTop: 1,
+            borderColor: "grey.300",
+            pt: 2,
+            mt: 6,
+            display: "flex",
+            flexDirection: { xs: "column", sm: "row" },
+            justifyContent: "space-between",
+            gap: 1,
+          }}
+        >
+          <Typography variant="caption" sx={{ display: "block" }}>
+            Ingangsdatum: juli 2025
+          </Typography>
+          <Typography
+            variant="caption"
+            sx={{ display: "block", textAlign: { xs: "left", sm: "right" } }}
+          >
+            © Research Data Alliance
+          </Typography>
+        </Box>
+      </Box>
+    ),
+  },
+};
+
+export default page;

--- a/packages/pages/src/Generic.tsx
+++ b/packages/pages/src/Generic.tsx
@@ -1,4 +1,4 @@
-import { useEffect } from "react";
+import { useEffect, isValidElement } from "react";
 import Container from "@mui/material/Container";
 import Grid from "@mui/material/Unstable_Grid2";
 import Button from "@mui/material/Button";
@@ -6,7 +6,7 @@ import Box from "@mui/material/Box";
 import Typography from "@mui/material/Typography";
 import { Link } from "react-router-dom";
 import type { Page } from "./types";
-import { lookupLanguageString } from "@dans-framework/utils";
+import { LanguageStrings, lookupLanguageString } from "@dans-framework/utils";
 import { useAuth } from "react-oidc-context";
 import { useTranslation } from "react-i18next";
 import { LoginButton } from "@dans-framework/user-auth";
@@ -20,7 +20,50 @@ const Generic = ({ logo, name, content, action }: Page) => {
 
   useEffect(() => {
     setSiteTitle(siteTitle, lookupLanguageString(name, i18n.language));
-  }, [siteTitle, name]);
+  }, [siteTitle, name, i18n.language]);
+
+  const renderContent = () => {
+    if (!content) return null;
+
+    if (isValidElement(content)) {
+      return content;
+    }
+
+    if (typeof content === "string") {
+      return parse(content);
+    }
+
+    // If content is an object, it could be LanguageStrings or LanguageContent
+    if (typeof content === "object") {
+      const currentLangContent = (content as any)[i18n.language];
+
+      if (currentLangContent !== undefined) {
+        if (isValidElement(currentLangContent)) {
+          return currentLangContent;
+        }
+
+        if (typeof currentLangContent === "string") {
+          return parse(currentLangContent);
+        }
+      }
+
+      // If no language-specific content found, try to use lookupLanguageString
+      // This will only work if the content is LanguageStrings (all values are strings)
+      if (Object.values(content).every((val) => typeof val === "string")) {
+        const stringContent = lookupLanguageString(
+          content as LanguageStrings,
+          i18n.language
+        );
+        return stringContent ? parse(stringContent) : null;
+      }
+    }
+
+    // If content type is not recognized, log a warning and return null
+    console.warn(
+      "Content type not supported or not recognized. Expected string, JSX, or LanguageStrings."
+    );
+    return null;
+  };
 
   return (
     <Container>
@@ -34,30 +77,28 @@ const Generic = ({ logo, name, content, action }: Page) => {
           xsOffset={logo ? 2 : 0}
         >
           <Typography variant="h1" sx={{ textAlign: "center" }}>
-            {logo ?
+            {logo ? (
               <img src={logo} alt="RDA" title="RDA" />
-            : lookupLanguageString(name, i18n.language)}
+            ) : (
+              lookupLanguageString(name, i18n.language)
+            )}
           </Typography>
         </Grid>
 
         <Grid xs={12} mdOffset={2.5} md={7}>
-          {content && (
-            <Box>
-              {parse(lookupLanguageString(content, i18n.language) || "")}
-            </Box>
-          )}
+          {content && <Box>{renderContent()}</Box>}
           {action && (
             <Box mt={4} display="flex" justifyContent="center">
-              {(
-                (action.restricted && auth.isAuthenticated) ||
-                !action.restricted
-              ) ?
+              {(action.restricted && auth.isAuthenticated) ||
+              !action.restricted ? (
                 <Link to={`/${action.link}`}>
                   <Button variant="contained" size="large">
                     {lookupLanguageString(action.text, i18n.language)}
                   </Button>
                 </Link>
-              : <LoginButton variant="contained" />}
+              ) : (
+                <LoginButton variant="contained" />
+              )}
             </Box>
           )}
         </Grid>

--- a/packages/pages/src/types/index.ts
+++ b/packages/pages/src/types/index.ts
@@ -1,5 +1,5 @@
 import type { LanguageStrings } from "@dans-framework/utils";
-import type { FunctionComponent } from 'react';
+import type { FunctionComponent, ReactNode } from "react";
 
 interface PageAction {
   link: string;
@@ -17,6 +17,13 @@ export type Template =
   | "mapper"
   | "rda-annotator";
 
+/**
+ * Type for language-specific content that can be either string or JSX
+ */
+export type LanguageContent = {
+  [key: string]: string | ReactNode;
+};
+
 export interface Page {
   id: string;
   name: string | LanguageStrings;
@@ -24,7 +31,7 @@ export interface Page {
   template?: Template;
   inMenu: boolean;
   menuTitle?: string | LanguageStrings;
-  content?: string | LanguageStrings;
+  content?: string | LanguageStrings | ReactNode | LanguageContent;
   action?: PageAction;
   logo?: any;
   restricted?: boolean; // display only when logged in


### PR DESCRIPTION
## Description

The commit adds the support for jsx content on the type generic page. The content can now be the following types basic strings, LanguageStrings example {nl: "hallo", en: "Hello" }, basic react nodes, and LanguageContent example { nl: (<Box>Hallo</Box>), en: (<Box>Hello</Box>) }.

It should be noted that the jsx version do require the page file to be a .tsx file.

## Related Issue(s)

[RDA-73](https://drivenbydata.atlassian.net/browse/RDA-73)

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Refactoring (changes that neither fixes a bug nor adds a feature)
- [ ] Performance improvement (changes that improve existing functionality)
- [ ] Test update (changes that modify tests)
- [ ] Other (please describe):

## Checklist

- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.


[RDA-73]: https://drivenbydata.atlassian.net/browse/RDA-73?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ