### PR TITLE
fix(rda): fix wrong label for footer about

### DIFF
--- a/apps/rda/src/config/footer.ts
+++ b/apps/rda/src/config/footer.ts
@@ -28,8 +28,8 @@ const footer: Footer = {
     },
     {
       header: {
-        en: "About RDA",
-        nl: "Over RDA",
+        en: "About RDA TIGER",
+        nl: "Over RDA TIGER",
       },
       links: [
         {


### PR DESCRIPTION
## Description

The label of the about section in the footer said RDA but should have been RDA TIGER

## Related Issue(s)

[RDA-76](https://drivenbydata.atlassian.net/browse/RDA-76)

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring (changes that neither fixes a bug nor adds a feature)
- [ ] Performance improvement (changes that improve existing functionality)
- [ ] Test update (changes that modify tests)
- [ ] Other (please describe):

## Checklist

- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
