### PR TITLE
feat(rda): consolidated privacy footer links

### DIFF
--- a/apps/rda/src/config/footer.ts
+++ b/apps/rda/src/config/footer.ts
@@ -41,61 +41,10 @@ const footer: Footer = {
         },
         {
           name: {
-            en: "Legal information",
-            nl: "Juridische informatie",
+            en: "Privacy Statement",
+            nl: "Privacyverklaring",
           },
           link: "",
-        },
-        {
-          name: {
-            en: "Press Releases",
-            nl: "Pers",
-          },
-          link: "",
-        },
-        {
-          name: {
-            en: "Disclaimer",
-            nl: "Disclaimer",
-          },
-          link: "/disclaimer",
-        },
-        {
-          name: {
-            en: "Data Licenses",
-            nl: "Datalicenties",
-          },
-          link: "",
-        },
-        {
-          name: {
-            en: "Privacy",
-            nl: "Privacy",
-          },
-          link: "",
-        },
-      ],
-    },
-    {
-      header: {
-        en: "Follow us",
-        nl: "Volg ons",
-      },
-      links: [
-        {
-          name: "Newsletter",
-          link: "",
-          icon: "email",
-        },
-        {
-          name: "YouTube",
-          link: "",
-          icon: "youtube",
-        },
-        {
-          name: "Twitter",
-          link: "",
-          icon: "twitter",
         },
       ],
     },


### PR DESCRIPTION
## Description

The privacy links in the footer section `About RDA TIGER` have been consolidated into a single item called `Privacy Statement`.

The commit also removes the social link section in the footer as it was deemed not necessary at this point.

## Related Issue(s)

[RDA-79](https://drivenbydata.atlassian.net/browse/RDA-79)

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring (changes that neither fixes a bug nor adds a feature)
- [ ] Performance improvement (changes that improve existing functionality)
- [ ] Test update (changes that modify tests)
- [ ] Other (please describe):

## Checklist

- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.




[RDA-79]: https://drivenbydata.atlassian.net/browse/RDA-79?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ