### PR TITLE
feat(freshdesk): add hook to control widget state

### DIFF
--- a/apps/rda/src/App.tsx
+++ b/apps/rda/src/App.tsx
@@ -19,7 +19,7 @@ import { RdaRecord } from "./pages/record";
 
 // Load config variables
 import theme from "./config/theme";
-import footer from "./config/footer";
+import { useFooterData } from "./config/footer";
 import pages from "./config/pages";
 import siteTitle from "./config/siteTitle";
 import languages from "./config/languages";
@@ -41,7 +41,8 @@ const App = () => {
   const { i18n } = useTranslation();
   const { isEmbed } = useEmbedHandler();
 
-  
+  const footer = useFooterData();
+
   const createElementByTemplate = (page: Page) => {
     switch (page.template) {
       case "dashboard":
@@ -196,7 +197,7 @@ const App = () => {
             </Link>
           </Box>
         )}
-        
+
         {!isEmbed && <Footer {...footer} />}
         <Freshdesk widgetId={80000010123} />
         <SupportDrawer

--- a/apps/rda/src/config/footer.ts
+++ b/apps/rda/src/config/footer.ts
@@ -1,85 +1,89 @@
 import { Footer } from "@dans-framework/layout/src/types";
 import rdaImage from "./images/logo_tiger.png";
 import rdaTiger from "./images/rda-tiger.svg";
+import { useFreshworksWidgetControl } from "@dans-framework/freshdesk";
 
-const footer: Footer = {
-  top: [
-    {
-      header: {
-        en: "Contact and service",
-        nl: "Contact en service",
-      },
-      links: [
-        {
-          name: {
-            en: "Contact",
-            nl: "Contact",
+
+export const useFooterData = (): Footer => {
+  const { openWidget } = useFreshworksWidgetControl();
+  return {
+    top: [
+      {
+        header: {
+          en: "Contact and service",
+          nl: "Contact en service",
+        },
+        links: [
+          {
+            name: {
+              en: "Contact",
+              nl: "Contact",
+            },
+            onClick: () => openWidget(),
           },
-          link: "",
-        },
-        {
-          name: {
-            en: "Helpdesk",
-            nl: "Helpdesk",
+          {
+            name: {
+              en: "Helpdesk",
+              nl: "Helpdesk",
+            },
+            onClick: () => openWidget(),
           },
-          link: "",
-        },
-      ],
-    },
-    {
-      header: {
-        en: "About RDA TIGER",
-        nl: "Over RDA TIGER",
+        ],
       },
-      links: [
-        {
-          name: {
-            en: "About us",
-            nl: "Over ons",
+      {
+        header: {
+          en: "About RDA TIGER",
+          nl: "Over RDA TIGER",
+        },
+        links: [
+          {
+            name: {
+              en: "About us",
+              nl: "Over ons",
+            },
+            link: "https://www.rd-alliance.org/working-groups/rda-tiger/",
           },
-          link: "https://www.rd-alliance.org/working-groups/rda-tiger/",
-        },
-        {
-          name: {
-            en: "Privacy Statement",
-            nl: "Privacyverklaring",
+          {
+            name: {
+              en: "Privacy Statement",
+              nl: "Privacyverklaring",
+            },
+            link: "",
           },
-          link: "",
+        ],
+      },
+      {
+        header: "RDA Tiger",
+        freetext:
+          "The RDA Tiger Project is supporting the use of this application through engagement with RDA Groups and members.",
+        links: [
+          {
+            name: "Contact RDA TIGER",
+            onClick: () => openWidget(),
+          },
+        ],
+      },
+      {
+        image: {
+          src: rdaImage,
+          alt: "DANS Logo",
         },
-      ],
-    },
-    {
-      header: "RDA Tiger",
-      freetext:
-        "The RDA Tiger Project is supporting the use of this application through engagement with RDA Groups and members.",
-      links: [
-        {
-          name: "Contact RDA TIGER",
-          link: "",
+      },
+    ],
+    bottom: [
+      {
+        image: {
+          src: rdaTiger,
+          alt: "RDA TIGER PROJECT",
+          width: 300,
         },
-      ],
-    },
-    {
-      image: {
-        src: rdaImage,
-        alt: "DANS Logo",
       },
-    },
-  ],
-  bottom: [
-    {
-      image: {
-        src: rdaTiger,
-        alt: "RDA TIGER PROJECT",
-        width: 300,
+      {
+        freetext: {
+          en: "This project has received funding from the European Union’s Horizon Europe framework programme under grant agreement No. 101094406. Views and opinions expressed are however those of the author(s) only and do not necessarily reflect those of the European Union or the European Research Executive Agency. Neither the European Union nor the European Research Executive Agency can be held responsible for them.",
+          nl: "Dit project is gefinancierd door het Horizon Europe-programma van de Europese Unie onder subsidieovereenkomst nr. 101094406. De opvattingen en meningen die hierin worden gepresenteerd, zijn echter die van de auteur(s) en weerspiegelen niet noodzakelijkerwijs die van de Europese Unie of het Europees Uitvoerend Agentschap voor Onderzoek. Noch de Europese Unie, noch het Europees Uitvoerend Agentschap voor Onderzoek kan hiervoor verantwoordelijk worden gehouden.",
+        },
       },
-    },
-    {
-      freetext: {
-        en: "This project has received funding from the European Union’s Horizon Europe framework programme under grant agreement No. 101094406. Views and opinions expressed are however those of the author(s) only and do not necessarily reflect those of the European Union or the European Research Executive Agency. Neither the European Union nor the European Research Executive Agency can be held responsible for them.",
-        nl: "Dit project is gefinancierd door het Horizon Europe-programma van de Europese Unie onder subsidieovereenkomst nr. 101094406. De opvattingen en meningen die hierin worden gepresenteerd, zijn echter die van de auteur(s) en weerspiegelen niet noodzakelijkerwijs die van de Europese Unie of het Europees Uitvoerend Agentschap voor Onderzoek. Noch de Europese Unie, noch het Europees Uitvoerend Agentschap voor Onderzoek kan hiervoor verantwoordelijk worden gehouden.",
-      },
-    },
-  ],
+    ],
+  };
 };
-export default footer;

--- a/packages/freshdesk/lib/index.tsx
+++ b/packages/freshdesk/lib/index.tsx
@@ -1,1 +1,2 @@
 export { default as Freshdesk } from "../src/freshdesk";
+export { useFreshworksWidgetControl } from "../src/useFreshworksWidgetControl";

--- a/packages/freshdesk/src/useFreshworksWidgetControl.ts
+++ b/packages/freshdesk/src/useFreshworksWidgetControl.ts
@@ -1,0 +1,62 @@
+import { useCallback } from "react";
+
+export interface FreshworksWidgetFunction {
+  (...args: any[]): void;
+  q?: any[];
+}
+
+// Hook that only provides control functions (no widget injection)
+export const useFreshworksWidgetControl = () => {
+  const openWidget = useCallback(() => {
+    const w = window as unknown as {
+      FreshworksWidget?: FreshworksWidgetFunction;
+    };
+
+    if (w.FreshworksWidget) {
+      w.FreshworksWidget("open");
+    } else {
+      console.warn(
+        "FreshworksWidget is not yet loaded. Make sure to initialize it first."
+      );
+    }
+  }, []);
+
+  const closeWidget = useCallback(() => {
+    const w = window as unknown as {
+      FreshworksWidget?: FreshworksWidgetFunction;
+    };
+
+    if (w.FreshworksWidget) {
+      w.FreshworksWidget("close");
+    } else {
+      console.warn("FreshworksWidget is not yet loaded");
+    }
+  }, []);
+
+  const hideWidget = useCallback(() => {
+    const w = window as unknown as {
+      FreshworksWidget?: FreshworksWidgetFunction;
+    };
+
+    if (w.FreshworksWidget) {
+      w.FreshworksWidget("hide");
+    }
+  }, []);
+
+  const showWidget = useCallback(() => {
+    const w = window as unknown as {
+      FreshworksWidget?: FreshworksWidgetFunction;
+    };
+
+    if (w.FreshworksWidget) {
+      w.FreshworksWidget("show");
+    }
+  }, []);
+
+  return {
+    openWidget,
+    closeWidget,
+    hideWidget,
+    showWidget,
+  };
+};

--- a/packages/layout/src/Footer.tsx
+++ b/packages/layout/src/Footer.tsx
@@ -11,6 +11,7 @@ import TwitterIcon from "@mui/icons-material/Twitter";
 import YouTubeIcon from "@mui/icons-material/YouTube";
 import EmailIcon from "@mui/icons-material/Email";
 import parse from "html-react-parser";
+import { Button } from "@mui/material";
 
 const Footer = ({ top, bottom }: FooterType) => {
   const columnsTop = top.length;
@@ -71,6 +72,22 @@ const FooterContent = ({
   bottom,
 }: FooterContent) => {
   const { i18n } = useTranslation();
+
+  const renderIcon = (icon?: string) => {
+    if (!icon) return null;
+
+    switch (icon) {
+      case "twitter":
+        return <TwitterIcon sx={{ mr: 1 }} fontSize="small" />;
+      case "youtube":
+        return <YouTubeIcon sx={{ mr: 1 }} fontSize="small" />;
+      case "email":
+        return <EmailIcon sx={{ mr: 1 }} fontSize="small" />;
+      default:
+        return null;
+    }
+  };
+
   return (
     <Stack direction="column" alignItems="start">
       {header && (
@@ -97,26 +114,49 @@ const FooterContent = ({
         </Box>
       )}
       {links &&
-        links.map((link, j) => (
-          <Link
-            href={link.link}
-            underline="none"
-            target="_blank"
-            key={`link-${j}`}
-            sx={{ display: "flex", alignItems: "center" }}
-          >
-            {link.icon && link.icon === "twitter" && (
-              <TwitterIcon sx={{ mr: 1 }} fontSize="small" />
-            )}
-            {link.icon && link.icon === "youtube" && (
-              <YouTubeIcon sx={{ mr: 1 }} fontSize="small" />
-            )}
-            {link.icon && link.icon === "email" && (
-              <EmailIcon sx={{ mr: 1 }} fontSize="small" />
-            )}
-            {lookupLanguageString(link.name, i18n.language)}
-          </Link>
-        ))}
+        links.map((item, j) => {
+          // Type guard: check if item has onClick property (Button)
+          if ("onClick" in item) {
+            return (
+              <Button
+                key={`button-${j}`}
+                onClick={item.onClick}
+                sx={{
+                  display: "flex",
+                  alignItems: "center",
+                  textDecoration: "none",
+                  textTransform: "none",
+                  padding: 0,
+                  minWidth: "auto",
+                  justifyContent: "flex-start",
+                  fontWeight: 400,
+                  // Font 13 px in rem
+                  fontSize: 16,
+                  "&:hover": {
+                    backgroundColor: "transparent",
+                  },
+                }}
+              >
+                {renderIcon(item.icon)}
+                {lookupLanguageString(item.name, i18n.language)}
+              </Button>
+            );
+          } else {
+            // It's a Link
+            return (
+              <Link
+                href={item.link}
+                underline="none"
+                target="_blank"
+                key={`link-${j}`}
+                sx={{ display: "flex", alignItems: "center" }}
+              >
+                {renderIcon(item.icon)}
+                {lookupLanguageString(item.name, i18n.language)}
+              </Link>
+            );
+          }
+        })}
     </Stack>
   );
 };

--- a/packages/layout/src/types/index.ts
+++ b/packages/layout/src/types/index.ts
@@ -7,7 +7,7 @@ export interface Footer {
 
 export interface FooterContent {
   header?: string | LanguageStrings;
-  links?: Link[];
+  links?: (Link | Button)[];
   freetext?: string | LanguageStrings;
   image?: {
     src: string;
@@ -21,5 +21,11 @@ export interface FooterContent {
 interface Link {
   name: string | LanguageStrings;
   link: string;
+  icon?: string;
+}
+
+interface Button {
+  name: string | LanguageStrings;
+  onClick: () => void;
   icon?: string;
 }


### PR DESCRIPTION
## Description

The commit adds a hook `useFreshworksWidgetControl` that enables the controll of the display.

The following methods are available:
- `openWidget`
- `closeWidget`
- `hideWidget`
- `showWidget`

## Related Issue(s)

[RDA-75](https://drivenbydata.atlassian.net/browse/RDA-75)

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring (changes that neither fixes a bug nor adds a feature)
- [ ] Performance improvement (changes that improve existing functionality)
- [ ] Test update (changes that modify tests)
- [ ] Other (please describe):

## Checklist

- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.

[RDA-75]: https://drivenbydata.atlassian.net/browse/RDA-75?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ